### PR TITLE
Fix mirrored EyeMovement directions

### DIFF
--- a/XenoKit/Engine/Scripting/BAC/Simulation/EyeMovementPositions.cs
+++ b/XenoKit/Engine/Scripting/BAC/Simulation/EyeMovementPositions.cs
@@ -6,15 +6,15 @@ namespace XenoKit.Engine.Scripting.BAC.Simulation
     {
         public static CustomVector4[] EyePositions = new CustomVector4[]
         {
-            new CustomVector4(0.1f, -0.1f, 0, 0), //Left, Up
+            new CustomVector4(-0.1f, -0.1f, 0, 0), //Left, Up
             new CustomVector4(0, -0.1f, 0, 0), //Up
-            new CustomVector4(-0.1f, -0.1f, 0, 0), //Right, Up
-            new CustomVector4(0.1f, 0, 0, 0), //Left
+            new CustomVector4(0.1f, -0.1f, 0, 0), //Right, Up
+            new CustomVector4(-0.1f, 0, 0, 0), //Left
             new CustomVector4(0, 0, 0, 0), //Default position
-            new CustomVector4(-0.1f, 0, 0, 0), //Right
-            new CustomVector4(0.1f, 0.1f, 0, 0), //Left, Down
+            new CustomVector4(0.1f, 0, 0, 0), //Right
+            new CustomVector4(-0.1f, 0.1f, 0, 0), //Left, Down
             new CustomVector4(0, 0.1f, 0, 0), //Down
-            new CustomVector4(-0.1f, 0.1f, 0, 0), //Right, Down
+            new CustomVector4(0.1f, 0.1f, 0, 0), //Right, Down
         };
     }
 }


### PR DESCRIPTION
the directions appeared mirrored in XenoKit viewport when compared to the game