### PR TITLE
Add known values

### DIFF
--- a/XenoKit/ViewModel/BAC/BACType0ViewModel.cs
+++ b/XenoKit/ViewModel/BAC/BACType0ViewModel.cs
@@ -148,6 +148,24 @@ namespace XenoKit.ViewModel.BAC
                 }
             }
         }
+        public ushort I_14
+        {
+            get
+            {
+                return bacType.I_14;
+            }
+            set
+            {
+                if (bacType.I_14 != value)
+                {
+                    // For some reason the undo and redo don't work for this value, probably overlooking something but the old/new value doesn't get applied to the checkbox - Pandas
+                    UndoManager.Instance.AddUndo(new UndoableProperty<BAC_Type0>(nameof(bacType.I_14), bacType, bacType.I_14, value, "Animation Face Animation from EAN"));
+                    bacType.I_14 = value;
+                    RaisePropertyChanged(() => I_14);
+                    UpdateBacPlayer();
+                }
+            }
+        }
 
         //Flags
         public bool MoveWithX
@@ -442,7 +460,7 @@ namespace XenoKit.ViewModel.BAC
                 }
             }
         }
-        
+
         //Ean
         public EAN_File SpecifiedEan
         {

--- a/XenoKit/Views/BAC/BacType0View.xaml
+++ b/XenoKit/Views/BAC/BacType0View.xaml
@@ -101,15 +101,21 @@
                                 <StackPanel Orientation="Horizontal">
                                     <StackPanel Margin="20, 5" Width="200">
                                         <CheckBox Content="Unk9" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType0View}}, Path=BacViewModel.Flags_Unk9, UpdateSourceTrigger=Default}"/>
-                                        <CheckBox Content="Unk10" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType0View}}, Path=BacViewModel.Flags_Unk10, UpdateSourceTrigger=Default}"/>
+                                        <CheckBox Content="Continue from Last Entry" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType0View}}, Path=BacViewModel.Flags_Unk10, UpdateSourceTrigger=Default}"/>
                                         <CheckBox Content="Unk11" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType0View}}, Path=BacViewModel.Flags_Unk11, UpdateSourceTrigger=Default}"/>
                                         <CheckBox Content="Unk12" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType0View}}, Path=BacViewModel.Flags_Unk12, UpdateSourceTrigger=Default}"/>
                                     </StackPanel>
                                     <StackPanel Margin="20, 5" Width="200">
-                                        <CheckBox Content="Unk13" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType0View}}, Path=BacViewModel.Flags_Unk13, UpdateSourceTrigger=Default}"/>
-                                        <CheckBox Content="Unk14" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType0View}}, Path=BacViewModel.Flags_Unk14, UpdateSourceTrigger=Default}"/>
+                                        <CheckBox Content="Ignore Root Motion" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType0View}}, Path=BacViewModel.Flags_Unk13, UpdateSourceTrigger=Default}" ToolTip="Ignore all root motion (b_C_Base). Any movement on the root bone will not be used."/>
+                                        <CheckBox Content="Specific per EAN type" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType0View}}, Path=BacViewModel.Flags_Unk14, UpdateSourceTrigger=Default}" ToolTip="Specific per EAN Type (Face Eye/Face Mouth). What this fully does is still unknown.&#x0a;&#x0a;Note: This is usually paired with face animation entries, usually the one with the 'Play animation from main ean' flag enabled."/>
                                         <CheckBox Content="Unk15" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType0View}}, Path=BacViewModel.Flags_Unk15, UpdateSourceTrigger=Default}"/>
                                         <CheckBox Content="Unk16" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType0View}}, Path=BacViewModel.Flags_Unk16, UpdateSourceTrigger=Default}"/>
+                                    </StackPanel>
+                                </StackPanel>
+
+                                <StackPanel Orientation="Horizontal">
+                                    <StackPanel Margin="20, 5" Width="225">
+                                        <CheckBox Content="Play Face Animation from Main EAN" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType0View}}, Path=BacViewModel.I_14, UpdateSourceTrigger=Default}" ToolTip="Plays the face animation that's baked into the chara / skill ean.&#x0a;&#x0a;Note: This is NOT recommended to do with CACs."/>
                                     </StackPanel>
                                 </StackPanel>
                             </StackPanel>

--- a/XenoKit/Views/BAC/BacType10View.xaml
+++ b/XenoKit/Views/BAC/BacType10View.xaml
@@ -80,23 +80,23 @@
 
                                 <StackPanel Orientation="Horizontal">
                                     <StackPanel Margin="20, 5" Width="170">
-                                        <CheckBox Content="Force All Players"  IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType10View}}, Path=BacViewModel.EnableCameraForAllPlayers, UpdateSourceTrigger=Default}" ToolTip="Force the camera to appear for all players."/>
+                                        <CheckBox Content="Play to All Players"  IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType10View}}, Path=BacViewModel.EnableCameraForAllPlayers, UpdateSourceTrigger=Default}" ToolTip="Force the camera to play for all players."/>
                                         <CheckBox Content="Focus On Target" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType10View}}, Path=BacViewModel.FocusOnTarget, UpdateSourceTrigger=Default}" ToolTip="Focus the camera on the current target."/>
-                                        <CheckBox Content="Chara Unique CAM.EAN" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType10View}}, Path=BacViewModel.UseCharacterSpecificCameraEan, UpdateSourceTrigger=Default}" ToolTip="Use a character unique EAN."/>
+                                        <CheckBox Content="Chara Unique CAM.EAN" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType10View}}, Path=BacViewModel.UseCharacterSpecificCameraEan, UpdateSourceTrigger=Default}" ToolTip="Use a character unique camera EAN."/>
                                         <CheckBox Content="Secondary" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType10View}}, Path=BacViewModel.DontOverrideActiveCameras, UpdateSourceTrigger=Default}" ToolTip="Only show this camera if there are no other cameras active (other than the default targetting camera)."/>
                                     </StackPanel>
                                     <StackPanel Margin="20, 5" Width="100">
                                         <CheckBox Content="Unk2" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType10View}}, Path=BacViewModel.Flag_74_1, UpdateSourceTrigger=Default}"/>
                                         <CheckBox Content="Unk5" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType10View}}, Path=BacViewModel.Flag_74_4, UpdateSourceTrigger=Default}"/>
-                                        <CheckBox Content="Unk6" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType10View}}, Path=BacViewModel.Flag_74_5, UpdateSourceTrigger=Default}"/>
+                                        <CheckBox Content="Enable Loop" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType10View}}, Path=BacViewModel.Flag_74_5, UpdateSourceTrigger=Default}" ToolTip="When this is active, the camera is able to be looped when the skill uses a looping mechanic."/>
                                     </StackPanel>
                                 </StackPanel>
 
                                 <StackPanel Orientation="Horizontal">
                                     <StackPanel Margin="20, 5" Width="170">
-                                        <CheckBox Content="Unk9" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType10View}}, Path=BacViewModel.CameraFlags_Unk9, UpdateSourceTrigger=Default}"/>
-                                        <CheckBox Content="Unk10" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType10View}}, Path=BacViewModel.CameraFlags_Unk10, UpdateSourceTrigger=Default}"/>
-                                        <CheckBox Content="Unk11" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType10View}}, Path=BacViewModel.CameraFlags_Unk11, UpdateSourceTrigger=Default}"/>
+                                        <CheckBox Content="Disable Photo Mode" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType10View}}, Path=BacViewModel.CameraFlags_Unk9, UpdateSourceTrigger=Default}" ToolTip="Disables the ability to move the camera in photo mode when camera is active."/>
+                                        <CheckBox Content="Snap to Camera" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType10View}}, Path=BacViewModel.CameraFlags_Unk10, UpdateSourceTrigger=Default}" ToolTip="When this is active, the previous camera instantly transitions (snaps) to this camera. No inbetween frames."/>
+                                        <CheckBox Content="Move to Camera" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType10View}}, Path=BacViewModel.CameraFlags_Unk11, UpdateSourceTrigger=Default}" ToolTip="When this is active, the previous camera transitions to this camera."/>
                                         <CheckBox Content="Unk12" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType10View}}, Path=BacViewModel.CameraFlags_Unk12, UpdateSourceTrigger=Default}"/>
                                     </StackPanel>
                                     <StackPanel Margin="20, 5" Width="100">

--- a/XenoKit/Views/BAC/BacType2View.xaml
+++ b/XenoKit/Views/BAC/BacType2View.xaml
@@ -84,8 +84,8 @@
                                 </StackPanel>
                                 <StackPanel Margin="20, 5" Width="200">
                                     <CheckBox Content="Unk1" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType2View}}, Path=BacViewModel.MovementFlags_A_1, UpdateSourceTrigger=Default}"/>
-                                    <CheckBox Content="Unk2" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType2View}}, Path=BacViewModel.MovementFlags_A_2, UpdateSourceTrigger=Default}"/>
-                                    <CheckBox Content="Unk3" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType2View}}, Path=BacViewModel.MovementFlags_A_3, UpdateSourceTrigger=Default}"/>
+                                    <CheckBox Content="Teleport to Random Opponents" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType2View}}, Path=BacViewModel.MovementFlags_A_2, UpdateSourceTrigger=Default}"/>
+                                    <CheckBox Content="Teleport to Center of Stage" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType2View}}, Path=BacViewModel.MovementFlags_A_3, UpdateSourceTrigger=Default}" ToolTip="Teleports the player to the center of the stage.&#x0a;&#x0a;Note: The XYZ direction values are used as offset values in this case."/>
                                     <CheckBox Content="Orientation Follows Input" IsChecked="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:BacType2View}}, Path=BacViewModel.MovementFlags_A_4, UpdateSourceTrigger=Default}"/>
                                 </StackPanel>
                             </StackPanel>


### PR DESCRIPTION
Adds more known values to some BAC Types, based off of the YaBAC Organizer values and my own notes.

Like I said in one of the commits, on the Animation BAC Type, I_14's checkbox doesn't work with undo and redo. I couldn't figure out what was wrong exactly, sorry for that.

I'll make another pull request on XV2 Tools that adds more functions for BACType15 and a BACType30 error fix.