### PR TITLE
Don't call update on audioplayer on every frame (Audio chopping bug)

### DIFF
--- a/XenoKit/Engine/Audio/CueInstance.cs
+++ b/XenoKit/Engine/Audio/CueInstance.cs
@@ -454,11 +454,11 @@ namespace XenoKit.Engine.Audio
                 return;
             }
 
-            //Update the audio players (3D Volume)
-            foreach(var audioPlayer in AudioPlayers)
-            {
-                audioPlayer.Update();
-            }
+            ////Update the audio players (3D Volume)
+            //foreach(var audioPlayer in AudioPlayers)
+            //{
+            //    audioPlayer.Update();
+            //}
 
             //Play the next sequential track
             if(AudioPlayers.Count == 0 && Tracks.Count > 0 && !locked)


### PR DESCRIPTION
In game, the appropriate volume is calculated once upon track creation, and the volume doesn't update afterwards even if the distance has changed; not until the track ends and starts playing again

This change simulates the correct in game behavior, and also solves the audio chopping bug as the device volume doesn't change again while the track is playing

the "Update" method was renamed to "CalculateVolume" and is now called from from "AsyncSetHcaAudio" task