### PR TITLE
Added proper interpolation for EyeMovement

### DIFF
--- a/XenoKit/Engine/Scripting/BAC/BacPlayer.cs
+++ b/XenoKit/Engine/Scripting/BAC/BacPlayer.cs
@@ -234,19 +234,18 @@ namespace XenoKit.Engine.Scripting.BAC
                 }
                 else
                 {
-                    CustomVector4 prevEyePosition = EyeMovementPositions.EyePositions[(int)eyeMovement.EyeDirectionPrev];
-                    CustomVector4 nextEyePosition = EyeMovementPositions.EyePositions[(int)eyeMovement.EyeDirectionNext];
+                    CustomVector4 prevEyePosition = EyeMovementPositions.EyePositions[(int)eyeMovement.EyeDirectionPrev] * eyeMovement.LeftEyeRotationPercent;
+                    CustomVector4 nextEyePosition = EyeMovementPositions.EyePositions[(int)eyeMovement.EyeDirectionNext] * eyeMovement.RightEyeRotationPercent;
 
-                    CustomVector4 leftEyePosition = (nextEyePosition - prevEyePosition) * eyeMovement.LeftEyeRotationPercent;
-                    CustomVector4 rightEyePosition = (nextEyePosition - prevEyePosition) * eyeMovement.RightEyeRotationPercent;
+                    CustomVector4 leftEyePosition = nextEyePosition;
+                    CustomVector4 rightEyePosition = nextEyePosition;
+
 
                     if (eyeMovement.StartTime + eyeMovement.EyeRotationFrames >= CurrentFrame)
                     {
-                        leftEyePosition.X *= 1f / eyeMovement.EyeRotationFrames * (CurrentFrame - eyeMovement.StartTime);
-                        leftEyePosition.Y *= 1f / eyeMovement.EyeRotationFrames * (CurrentFrame - eyeMovement.StartTime);
-
-                        rightEyePosition.X *= 1f / eyeMovement.EyeRotationFrames * (CurrentFrame - eyeMovement.StartTime);
-                        rightEyePosition.Y *= 1f / eyeMovement.EyeRotationFrames * (CurrentFrame - eyeMovement.StartTime);
+                        float factor = 1f / eyeMovement.EyeRotationFrames * (CurrentFrame - eyeMovement.StartTime);
+                        leftEyePosition = CustomVector4.Lerp(prevEyePosition, nextEyePosition,factor);
+                        rightEyePosition = CustomVector4.Lerp(prevEyePosition, nextEyePosition, factor);
                     }
 
                     character.EyeIrisLeft_UV[0] = leftEyePosition.X;


### PR DESCRIPTION
In the previous code, the vectors were subtracted from each other but it didn't result in a vector that goes from Prev Direction to Next Direction, instead it made the Next direction stronger.

so for instance, if "Left" was Prev ((-0.1f, 0, 0, 0)) and "Right" was Next ((0.1f, 0, 0, 0)) the result would be ((0.2f, 0, 0, 0)) which is just a stronger "Right" vector.
and the eyes would always interpolate from "None" Direction to the stronger Next.

this PR adds interpolation using Lerp function (implemented in XV2CoreLib.LB_Common.Numbers) 
[(XenoKit) Added Lerp function for use in Interpolation operations on CustomVector4 #73](https://github.com/LazyBone152/XV2-Tools/pull/73#issue-1722938543)

![Untitled Project](https://github.com/LazyBone152/XenoKit/assets/47185022/b241efd8-99fe-4627-8caa-41edcb690151)

if the Rotation Percent didn't match between the 2 consecutive EyeMovement entries, it would do that jump that you see when the eyes go up, the same happens in game
