### PR TITLE
check b_C_Base index before updating node

### DIFF
--- a/XenoKit/Engine/Animation/AnimationPlayer.cs
+++ b/XenoKit/Engine/Animation/AnimationPlayer.cs
@@ -134,7 +134,8 @@ namespace XenoKit.Engine.Animation
                 //Update the base node only, skiping all other bones (not needed).
                 if(PrimaryAnimation != null)
                 {
-                    UpdateNode(PrimaryAnimation, PrimaryAnimation.b_C_Base_Index);
+                    if (PrimaryAnimation.b_C_Base_Index != -1)
+                        UpdateNode(PrimaryAnimation, PrimaryAnimation.b_C_Base_Index);
                 }
 
                 HandleFinishedAnimations();


### PR DESCRIPTION
When exporting animations with EmdFBX, it won't add "b_C_Base" Node if it has no keyframes, this is common when exporting Dragon Ball Legends animations.
this raises an error on Xenokit, so we need to check if the index was found before updating first

this also causes a lot of odd bugs in-game, so i tried to Log a Warning to the user that no keyframes exist
but tbh i'm not sure how to Log it only once (it triggers 50+ times per seeked frame)