### PR TITLE
Improve hitbox preview accuracy with CBS data

### DIFF
--- a/XenoKit/Engine/Animation/Xv2Skeleton.cs
+++ b/XenoKit/Engine/Animation/Xv2Skeleton.cs
@@ -255,7 +255,12 @@ namespace XenoKit.Engine.Animation
         {
             return CurrentBoneScale == body;
         }
-        
+
+        public int GetActiveBoneScaleId()
+        {
+            return CurrentBoneScale?.ID ?? 0;
+        }
+
         #endregion
 
         #region Helpers

--- a/XenoKit/Engine/Gizmo/HitboxGizmo.cs
+++ b/XenoKit/Engine/Gizmo/HitboxGizmo.cs
@@ -1,8 +1,11 @@
-﻿using System;
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
+using System;
+using XenoKit.Editor;
 using XenoKit.Engine.Shapes;
 using XenoKit.Engine.View;
 using Xv2CoreLib.BAC;
+using Xv2CoreLib.CBS;
+using static Xv2CoreLib.Xenoverse2;
 
 namespace XenoKit.Engine.Gizmo
 {
@@ -87,9 +90,32 @@ namespace XenoKit.Engine.Gizmo
                 {
                     isBaseBone = boneName == Xv2CoreLib.ESK.ESK_File.BaseBone;
                     boneIdx = SceneManager.Actors[0].Skeleton.GetBoneIndex(boneName);
+                    CBS_Entry cbsEntry = actor.CharacterData.CbsEntry.Find(x => x.BodyId == actor.Skeleton.GetActiveBoneScaleId());
+                    float cbsScaling = 1f;
+
+                    if (cbsEntry != null)
+                    {
+                        switch (Files.Instance.SelectedItem.SelectedBacFile.MoveType)
+                        {
+                            case MoveType.Character:
+                                cbsScaling = cbsEntry.F_04;
+                                break;
+                            case MoveType.Skill:
+                                cbsScaling = cbsEntry.F_12;
+                                break;
+                            default:
+                                cbsScaling = 1f;
+                                break;
+                        }
+                    }
 
                     //BAC Hitbox bounds are defined in half-metres (1.0 is actually 0.5)
-                    BoundingBox.SetBounds(new Vector3(hitbox.MinX, hitbox.MinY, hitbox.MinZ) / 2, new Vector3(hitbox.MaxX, hitbox.MaxY, hitbox.MaxZ) / 2, hitbox.Size / 2, hitbox.BoundingBoxType != BAC_Type1.BoundingBoxTypeEnum.Uniform);
+                    BoundingBox.SetBounds(
+                        new Vector3(hitbox.MinX, (Hitbox.MinY + 0.5f), hitbox.MinZ) * cbsScaling, 
+                        new Vector3(hitbox.MaxX, hitbox.MaxY, hitbox.MaxZ) * cbsScaling,
+                        hitbox.Size * cbsScaling / 2f, 
+                        hitbox.BoundingBoxType != BAC_Type1.BoundingBoxTypeEnum.Uniform
+                    );
                     BoundingBox.SetPosition(new Vector3(hitbox.PositionX, hitbox.PositionY, hitbox.PositionZ));
                 }
 

--- a/XenoKit/Engine/Scripting/BAC/Simulation/HitboxPreview.cs
+++ b/XenoKit/Engine/Scripting/BAC/Simulation/HitboxPreview.cs
@@ -1,7 +1,9 @@
 ﻿using Microsoft.Xna.Framework;
 using System;
+using System.Linq;
 using XenoKit.Engine.Shapes;
 using Xv2CoreLib.BAC;
+using Xv2CoreLib.CBS;
 using Xv2CoreLib.Resource.App;
 
 namespace XenoKit.Engine.Scripting.BAC.Simulation
@@ -87,9 +89,32 @@ namespace XenoKit.Engine.Scripting.BAC.Simulation
                 {
                     isBaseBone = boneName == Xv2CoreLib.ESK.ESK_File.BaseBone;
                     boneIdx = SceneManager.Actors[0].Skeleton.GetBoneIndex(boneName);
+                    CBS_Entry cbsEntry = actor.CharacterData.CbsEntry.Find(x => x.BodyId == actor.Skeleton.GetActiveBoneScaleId());
+                    float cbsScaling = 1f;
+
+                    if (cbsEntry != null)
+                    {
+                        switch (ParentBacInstance.SkillMove.MoveType)
+                        {
+                            case Editor.Move.Type.Moveset:
+                                cbsScaling = cbsEntry.F_04;
+                                break;
+                            case Editor.Move.Type.Skill:
+                                cbsScaling = cbsEntry.F_12;
+                                break;
+                            default:
+                                cbsScaling = 1f;
+                                break;
+                        }
+                    }
 
                     //BAC Hitbox bounds are defined in half-metres (1.0 is actually 0.5)
-                    BoundingBox.SetBounds(new Vector3(Hitbox.MinX, Hitbox.MinY, Hitbox.MinZ) / 2, new Vector3(Hitbox.MaxX, Hitbox.MaxY, Hitbox.MaxZ) / 2, Hitbox.Size / 2, Hitbox.BoundingBoxType != BAC_Type1.BoundingBoxTypeEnum.Uniform);
+                    BoundingBox.SetBounds(
+                        new Vector3(Hitbox.MinX, (Hitbox.MinY + 0.5f), Hitbox.MinZ) * cbsScaling, 
+                        new Vector3(Hitbox.MaxX, Hitbox.MaxY, Hitbox.MaxZ) * cbsScaling,
+                        Hitbox.Size * cbsScaling / 2f, 
+                        Hitbox.BoundingBoxType != BAC_Type1.BoundingBoxTypeEnum.Uniform
+                    );
                     BoundingBox.SetPosition(new Vector3(Hitbox.PositionX, Hitbox.PositionY, Hitbox.PositionZ));
                 }
             }

--- a/XenoKit/Engine/Shapes/Cube.cs
+++ b/XenoKit/Engine/Shapes/Cube.cs
@@ -19,10 +19,12 @@ namespace XenoKit.Engine.Shapes
         public Vector3 Scale;
         public Vector3 MinBounds;
         public Vector3 MaxBounds;
+        public bool useBounds;
         private Color Color;
         private float _initalSize;
         private Vector3 _initialMinBounds;
         private Vector3 _initialMaxBounds;
+        private bool _initialUseBounds;
 
         //Settings:
         private readonly bool Wireframe = false;
@@ -202,12 +204,13 @@ namespace XenoKit.Engine.Shapes
         public void SetBounds(Vector3 min, Vector3 max, float size, bool useDefinedBounds)
         {
             //Early out if bounds are already equal to input values
-            if (min.IsAproxEqual(_initialMinBounds) && max.IsAproxEqual(_initialMaxBounds) && MathHelpers.FloatEquals(size, _initalSize))
+            if (min.IsAproxEqual(_initialMinBounds) && max.IsAproxEqual(_initialMaxBounds) && MathHelpers.FloatEquals(size, _initalSize) && useDefinedBounds == _initialUseBounds)
                 return;
 
             _initalSize = size;
             _initialMinBounds = min;
             _initialMaxBounds = max;
+            _initialUseBounds = useDefinedBounds;
 
             if (useDefinedBounds)
             {


### PR DESCRIPTION
Uses CBS file data to line the hitbox preview up more closely with what the game does. Depends on the XV2-Tools cbs-parser change.