### PR TITLE
Add a BCM editor

### DIFF
--- a/XenoKit/Editor/Files/EditorVisibility.cs
+++ b/XenoKit/Editor/Files/EditorVisibility.cs
@@ -25,15 +25,12 @@ namespace XenoKit.Editor
         public Visibility ActionVisibility { get; private set; } = Visibility.Collapsed;
         public Visibility EffectVisibility { get; private set; } = Visibility.Collapsed;
         public Visibility AudioVisibility { get; private set; } = Visibility.Collapsed;
-        public Visibility HitboxVisibility { get; private set; } = Visibility.Collapsed;
         public Visibility ProjectileVisibility { get; private set; } = Visibility.Collapsed;
         public Visibility CameraVisibility { get; private set; } = Visibility.Collapsed;
         public Visibility SystemVisibility { get; private set; } = Visibility.Collapsed;
         public Visibility CacVisibility { get; private set; } = Visibility.Collapsed;
 
         //SubTabs:
-        public Visibility ShotBdmVisibility { get; private set; } = Visibility.Collapsed;
-        public Visibility BdmVisibility { get; private set; } = Visibility.Collapsed;
         public Visibility SeVisibility { get; private set; } = Visibility.Collapsed;
         public Visibility VoxVisibility { get; private set; } = Visibility.Collapsed;
 
@@ -52,24 +49,22 @@ namespace XenoKit.Editor
             else if (type == OutlinerItemType.CMN)
             {
                 AnimationVisibility = Visibility.Visible;
+                StateVisibility = Visibility.Visible;
                 ActionVisibility = Visibility.Visible;
                 EffectVisibility = Visibility.Visible;
                 AudioVisibility = Visibility.Visible;
                 SeVisibility = Visibility.Visible;
-                HitboxVisibility = Visibility.Visible;
                 ProjectileVisibility = Visibility.Visible;
                 CameraVisibility = Visibility.Visible;
-                BdmVisibility = Visibility.Visible;
-                ShotBdmVisibility = Visibility.Visible;
             }
             else if (type == OutlinerItemType.Character || type == OutlinerItemType.Moveset)
             {
                 AnimationVisibility = Visibility.Visible;
+                StateVisibility = Visibility.Visible;
                 ActionVisibility = Visibility.Visible;
                 EffectVisibility = Visibility.Visible;
                 AudioVisibility = Visibility.Visible;
                 SeVisibility = Visibility.Visible;
-                HitboxVisibility = Visibility.Visible;
                 CameraVisibility = Visibility.Visible;
 
                 if(type == OutlinerItemType.Character)
@@ -82,17 +77,15 @@ namespace XenoKit.Editor
             else if (type == OutlinerItemType.Skill)
             {
                 AnimationVisibility = Visibility.Visible;
+                StateVisibility = Visibility.Visible;
                 ActionVisibility = Visibility.Visible;
                 EffectVisibility = Visibility.Visible;
                 AudioVisibility = Visibility.Visible;
                 SeVisibility = Visibility.Visible;
                 VoxVisibility = Visibility.Visible;
-                HitboxVisibility = Visibility.Visible;
                 ProjectileVisibility = Visibility.Visible;
                 CameraVisibility = Visibility.Visible;
                 SystemVisibility = Visibility.Visible;
-                BdmVisibility = Visibility.Visible;
-                ShotBdmVisibility = Visibility.Visible;
             }
             else if(type == OutlinerItemType.ACB)
             {
@@ -111,12 +104,6 @@ namespace XenoKit.Editor
             {
                 CameraVisibility = Visibility.Visible;
             }
-
-
-            //Set all unimplemented tabs to be collapsed.
-            StateVisibility = Visibility.Collapsed;
-            HitboxVisibility = Visibility.Collapsed;
-            ProjectileVisibility = Visibility.Collapsed;
             SystemVisibility = Visibility.Collapsed;
         }
 

--- a/XenoKit/Helper/Find.cs
+++ b/XenoKit/Helper/Find.cs
@@ -137,15 +137,22 @@ namespace XenoKit.Helper.Find
     {
         public Type valueType;
         public string valueName;
+        public string displayName;
         public object value;
         public object parent;
 
-        public string ValueName => valueName;
+        public string ValueName => string.IsNullOrWhiteSpace(displayName) ? valueName : displayName;
 
         public Value(Type _valueType, string _valueName, object _value, object _parent)
+            : this(_valueType, _valueName, _value, _parent, null)
+        {
+        }
+
+        public Value(Type _valueType, string _valueName, object _value, object _parent, string _displayName)
         {
             valueType = _valueType;
             valueName = _valueName;
+            displayName = _displayName;
             value = _value;
             parent = _parent;
         }

--- a/XenoKit/MainWindow.xaml
+++ b/XenoKit/MainWindow.xaml
@@ -79,8 +79,8 @@
 
         </Grid>
 
-        <GridSplitter Grid.Column="1" Grid.Row="1" Grid.RowSpan="3" Width="5" HorizontalAlignment="Stretch" Background="{DynamicResource MahApps.Brushes.Accent}" Margin="0.145,0,0.091,0.327"/>
-        <GridSplitter Grid.Column="3" Grid.Row="2" ResizeDirection="Rows" Height="3" HorizontalAlignment="Stretch" Background="{DynamicResource MahApps.Brushes.Accent}"/>
+        <GridSplitter x:Name="editorSceneSplitter" Grid.Column="1" Grid.Row="1" Grid.RowSpan="3" Width="5" HorizontalAlignment="Stretch" Background="{DynamicResource MahApps.Brushes.Accent}" Margin="0.145,0,0.091,0.327"/>
+        <GridSplitter x:Name="sceneLogSplitter" Grid.Column="3" Grid.Row="2" ResizeDirection="Rows" Height="3" HorizontalAlignment="Stretch" Background="{DynamicResource MahApps.Brushes.Accent}"/>
         <GridSplitter Grid.Column="3" Grid.Row="1" Grid.RowSpan="3" Width="5" HorizontalAlignment="Stretch" Background="{DynamicResource MahApps.Brushes.Accent}"/>
 
 
@@ -145,10 +145,13 @@
                     <_controls:BacTab x:Name="bacControlView" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"/>
                 </Grid>
             </Controls:MetroTabItem>
-            <Controls:MetroTabItem Header="State" Controls:HeaderedControlHelper.HeaderFontSize="14" Visibility="{Binding Source={x:Static editor:Files.Instance}, Path=SelectedItem.Visibilities.StateVisibility}"/>
+            <Controls:MetroTabItem x:Name="stateTab" Header="State" Controls:HeaderedControlHelper.HeaderFontSize="14" Visibility="{Binding Source={x:Static editor:Files.Instance}, Path=SelectedItem.Visibilities.StateVisibility}">
+                <_views:BcmTab x:Name="bcmTabView" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"/>
+            </Controls:MetroTabItem>
 
-            <Controls:MetroTabItem Header="Projectile" Controls:HeaderedControlHelper.HeaderFontSize="14" Visibility="{Binding Source={x:Static editor:Files.Instance}, Path=SelectedItem.Visibilities.ProjectileVisibility}"/>
-            <Controls:MetroTabItem Header="Hitbox" Controls:HeaderedControlHelper.HeaderFontSize="14" Visibility="{Binding Source={x:Static editor:Files.Instance}, Path=SelectedItem.Visibilities.HitboxVisibility}"/>
+            <Controls:MetroTabItem Header="Projectile" Controls:HeaderedControlHelper.HeaderFontSize="14" Visibility="{Binding Source={x:Static editor:Files.Instance}, Path=SelectedItem.Visibilities.ProjectileVisibility}">
+                <_views:BsaTab HorizontalAlignment="Stretch" VerticalAlignment="Stretch"/>
+            </Controls:MetroTabItem>
             <Controls:MetroTabItem Header="Effect" Controls:HeaderedControlHelper.HeaderFontSize="14" Visibility="{Binding Source={x:Static editor:Files.Instance}, Path=SelectedItem.Visibilities.EffectVisibility}">
                 <Grid>
                     <Grid.RowDefinitions>

--- a/XenoKit/Views/BCM/BcmBitGroupView.xaml
+++ b/XenoKit/Views/BCM/BcmBitGroupView.xaml
@@ -1,0 +1,12 @@
+<UserControl x:Class="XenoKit.Views.BCM.BcmBitGroupView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Name="Root">
+    <GroupBox Header="{Binding ElementName=Root, Path=Title}"
+              Foreground="{DynamicResource MahApps.Brushes.Text}"
+              BorderBrush="{DynamicResource MahApps.Brushes.Gray.SemiTransparent}"
+              Margin="0,0,0,14"
+              Padding="8">
+        <WrapPanel x:Name="groupsPanel"/>
+    </GroupBox>
+</UserControl>

--- a/XenoKit/Views/BCM/BcmBitGroupView.xaml.cs
+++ b/XenoKit/Views/BCM/BcmBitGroupView.xaml.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace XenoKit.Views.BCM
+{
+    public partial class BcmBitGroupView : UserControl
+    {
+        public event EventHandler ValueChanged;
+
+        private readonly List<BcmChoiceGroup> groups = new List<BcmChoiceGroup>();
+        private bool isRefreshing;
+
+        public static readonly DependencyProperty TitleProperty = DependencyProperty.Register(
+            nameof(Title), typeof(string), typeof(BcmBitGroupView), new PropertyMetadata(string.Empty));
+
+        public static readonly DependencyProperty ValueProperty = DependencyProperty.Register(
+            nameof(Value), typeof(uint), typeof(BcmBitGroupView), new PropertyMetadata(0u, ValuePropertyChanged));
+
+        public string Title
+        {
+            get => (string)GetValue(TitleProperty);
+            set => SetValue(TitleProperty, value);
+        }
+
+        public uint Value
+        {
+            get => (uint)GetValue(ValueProperty);
+            set => SetValue(ValueProperty, value);
+        }
+
+        public BcmBitGroupView()
+        {
+            InitializeComponent();
+        }
+
+        public void SetGroups(IEnumerable<BcmChoiceGroup> newGroups)
+        {
+            groups.Clear();
+            groups.AddRange(newGroups ?? Enumerable.Empty<BcmChoiceGroup>());
+            BuildGroups();
+            RefreshValue();
+        }
+
+        private static void ValuePropertyChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
+        {
+            ((BcmBitGroupView)dependencyObject).RefreshValue();
+        }
+
+        private void BuildGroups()
+        {
+            groupsPanel.Children.Clear();
+
+            foreach (BcmChoiceGroup group in groups)
+            {
+                bool skipInnerHeader = groups.Count == 1 && string.IsNullOrWhiteSpace(group.Title);
+                FrameworkElement groupElement;
+                Panel choicePanel = skipInnerHeader ? (Panel)new WrapPanel() : new StackPanel();
+
+                if (skipInnerHeader)
+                {
+                    groupElement = choicePanel;
+                    groupElement.Margin = new Thickness(0, 0, 10, 8);
+                }
+                else
+                {
+                    GroupBox groupBox = new GroupBox
+                    {
+                        Header = group.Title,
+                        Width = 210,
+                        Margin = new Thickness(0, 0, 10, 8),
+                        Padding = new Thickness(6)
+                    };
+                    groupBox.SetResourceReference(ForegroundProperty, "MahApps.Brushes.Text");
+                    groupBox.SetResourceReference(BorderBrushProperty, "MahApps.Brushes.Gray.SemiTransparent");
+                    groupBox.Content = choicePanel;
+                    groupElement = groupBox;
+                }
+
+                groupElement.Tag = group;
+
+                foreach (BcmChoice choice in group.Choices)
+                {
+                    double labelWidth = skipInnerHeader ? 138 : 178;
+                    CheckBox checkBox = new CheckBox
+                    {
+                        Tag = choice,
+                        Width = skipInnerHeader ? 166 : double.NaN,
+                        Margin = skipInnerHeader ? new Thickness(0, 2, 12, 2) : new Thickness(0, 1, 0, 1),
+                        VerticalContentAlignment = skipInnerHeader ? VerticalAlignment.Center : VerticalAlignment.Top,
+                        Content = new TextBlock
+                        {
+                            Text = choice.Label,
+                            TextWrapping = TextWrapping.Wrap,
+                            MaxWidth = labelWidth,
+                            VerticalAlignment = skipInnerHeader ? VerticalAlignment.Center : VerticalAlignment.Top
+                        }
+                    };
+                    checkBox.ToolTip = string.IsNullOrWhiteSpace(choice.ToolTip) ? choice.Label : choice.ToolTip;
+                    checkBox.Checked += CheckBoxChanged;
+                    checkBox.Unchecked += CheckBoxChanged;
+                    choicePanel.Children.Add(checkBox);
+                }
+
+                groupsPanel.Children.Add(groupElement);
+            }
+        }
+
+        private void RefreshValue()
+        {
+            isRefreshing = true;
+
+            foreach (FrameworkElement groupElement in groupsPanel.Children.OfType<FrameworkElement>())
+            {
+                Panel panel = groupElement is GroupBox groupBox ? groupBox.Content as Panel : groupElement as Panel;
+                if (panel == null) continue;
+
+                foreach (CheckBox checkBox in panel.Children.OfType<CheckBox>())
+                {
+                    if (checkBox.Tag is BcmChoice choice)
+                        checkBox.IsChecked = (Value & choice.Value) == choice.Value && choice.Value != 0;
+                }
+            }
+
+            isRefreshing = false;
+        }
+
+        private void CheckBoxChanged(object sender, RoutedEventArgs e)
+        {
+            if (isRefreshing) return;
+
+            uint knownMask = 0;
+            foreach (BcmChoice choice in groups.SelectMany(group => group.Choices))
+                knownMask |= choice.Value;
+
+            uint newValue = Value & ~knownMask;
+
+            foreach (FrameworkElement groupElement in groupsPanel.Children.OfType<FrameworkElement>())
+            {
+                Panel panel = groupElement is GroupBox groupBox ? groupBox.Content as Panel : groupElement as Panel;
+                if (panel == null) continue;
+
+                foreach (CheckBox checkBox in panel.Children.OfType<CheckBox>())
+                {
+                    if (checkBox.IsChecked == true && checkBox.Tag is BcmChoice choice)
+                        newValue |= choice.Value;
+                }
+            }
+
+            SetValueFromControl(newValue);
+        }
+
+        private void SetValueFromControl(uint value)
+        {
+            if (Value == value) return;
+
+            Value = value;
+            ValueChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    public class BcmChoice
+    {
+        public string Label { get; set; }
+        public uint Value { get; set; }
+        public string ToolTip { get; set; }
+
+        public BcmChoice(string label, uint value, string toolTip = null)
+        {
+            Label = label;
+            Value = value;
+            ToolTip = toolTip;
+        }
+    }
+
+    public class BcmChoiceGroup
+    {
+        public string Title { get; set; }
+        public IList<BcmChoice> Choices { get; set; }
+
+        public BcmChoiceGroup(string title, params BcmChoice[] choices)
+        {
+            Title = title;
+            Choices = choices;
+        }
+    }
+}

--- a/XenoKit/Views/BCM/BcmEntryEditor.Fields.cs
+++ b/XenoKit/Views/BCM/BcmEntryEditor.Fields.cs
@@ -16,52 +16,55 @@ namespace XenoKit.Views.BCM
             PropertyInfo property = GetProperty(propertyName);
             if (property == null) return;
 
+            BCM_Entry entry = SelectedEntry;
             Grid row = CreateEditorRow(labelText);
 
             TextBox textBox = new TextBox
             {
                 MinWidth = 100,
                 HorizontalAlignment = HorizontalAlignment.Stretch,
-                Text = FormatValue(property.GetValue(SelectedEntry, null), valueMode)
+                Text = FormatValue(property.GetValue(entry, null), valueMode)
             };
             textBox.ToolTip = labelText;
-            textBox.LostFocus += (sender, args) => ApplyEditorValue(textBox, property, valueMode);
+            textBox.LostFocus += (sender, args) => ApplyEditorValue(textBox, entry, property, valueMode);
             if (commitOnTextChanged)
-                textBox.TextChanged += (sender, args) => ApplyEditorValue(textBox, property, valueMode, false);
+                textBox.TextChanged += (sender, args) => ApplyEditorValue(textBox, entry, property, valueMode, false);
             textBox.KeyDown += (sender, args) =>
             {
                 if (args.Key == Key.Enter)
                 {
-                    ApplyEditorValue(textBox, property, valueMode);
+                    ApplyEditorValue(textBox, entry, property, valueMode);
                     args.Handled = true;
                 }
             };
+
+            pendingCommits.Add(() => ApplyEditorValue(textBox, entry, property, valueMode, false));
 
             Grid.SetColumn(textBox, 1);
             row.Children.Add(textBox);
             panel.Children.Add(row);
         }
 
-        private void ApplyEditorValue(TextBox textBox, PropertyInfo property, EditorValueMode valueMode, bool updateText = true)
+        private void ApplyEditorValue(TextBox textBox, BCM_Entry entry, PropertyInfo property, EditorValueMode valueMode, bool updateText = true)
         {
             if (TryConvertText(textBox.Text, property.PropertyType, valueMode, out object value))
             {
-                SetProperty(property, value);
+                SetProperty(entry, property, value);
                 if (updateText)
-                    textBox.Text = FormatValue(property.GetValue(SelectedEntry, null), valueMode);
+                    textBox.Text = FormatValue(property.GetValue(entry, null), valueMode);
                 return;
             }
 
-            textBox.Text = FormatValue(property.GetValue(SelectedEntry, null), valueMode);
+            textBox.Text = FormatValue(property.GetValue(entry, null), valueMode);
         }
 
-        private void SetProperty(PropertyInfo property, object value)
+        private void SetProperty(BCM_Entry entry, PropertyInfo property, object value)
         {
-            object oldValue = property.GetValue(SelectedEntry, null);
+            object oldValue = property.GetValue(entry, null);
             if (Equals(oldValue, value)) return;
 
-            UndoManager.Instance.AddUndo(new UndoablePropertyGeneric(property.Name, SelectedEntry, oldValue, value, property.Name));
-            property.SetValue(SelectedEntry, value, null);
+            UndoManager.Instance.AddUndo(new UndoablePropertyGeneric(property.Name, entry, oldValue, value, property.Name));
+            property.SetValue(entry, value, null);
             EntryEdited?.Invoke(this, EventArgs.Empty);
         }
 

--- a/XenoKit/Views/BCM/BcmEntryEditor.Fields.cs
+++ b/XenoKit/Views/BCM/BcmEntryEditor.Fields.cs
@@ -1,0 +1,179 @@
+﻿using System;
+using System.Globalization;
+using System.Reflection;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using Xv2CoreLib.BCM;
+using Xv2CoreLib.Resource.UndoRedo;
+
+namespace XenoKit.Views.BCM
+{
+    public partial class BcmEntryEditor : UserControl
+    {
+        private void AddEditor(Panel panel, string labelText, string propertyName, EditorValueMode valueMode, bool commitOnTextChanged = false)
+        {
+            PropertyInfo property = GetProperty(propertyName);
+            if (property == null) return;
+
+            Grid row = CreateEditorRow(labelText);
+
+            TextBox textBox = new TextBox
+            {
+                MinWidth = 100,
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                Text = FormatValue(property.GetValue(SelectedEntry, null), valueMode)
+            };
+            textBox.ToolTip = labelText;
+            textBox.LostFocus += (sender, args) => ApplyEditorValue(textBox, property, valueMode);
+            if (commitOnTextChanged)
+                textBox.TextChanged += (sender, args) => ApplyEditorValue(textBox, property, valueMode, false);
+            textBox.KeyDown += (sender, args) =>
+            {
+                if (args.Key == Key.Enter)
+                {
+                    ApplyEditorValue(textBox, property, valueMode);
+                    args.Handled = true;
+                }
+            };
+
+            Grid.SetColumn(textBox, 1);
+            row.Children.Add(textBox);
+            panel.Children.Add(row);
+        }
+
+        private void ApplyEditorValue(TextBox textBox, PropertyInfo property, EditorValueMode valueMode, bool updateText = true)
+        {
+            if (TryConvertText(textBox.Text, property.PropertyType, valueMode, out object value))
+            {
+                SetProperty(property, value);
+                if (updateText)
+                    textBox.Text = FormatValue(property.GetValue(SelectedEntry, null), valueMode);
+                return;
+            }
+
+            textBox.Text = FormatValue(property.GetValue(SelectedEntry, null), valueMode);
+        }
+
+        private void SetProperty(PropertyInfo property, object value)
+        {
+            object oldValue = property.GetValue(SelectedEntry, null);
+            if (Equals(oldValue, value)) return;
+
+            UndoManager.Instance.AddUndo(new UndoablePropertyGeneric(property.Name, SelectedEntry, oldValue, value, property.Name));
+            property.SetValue(SelectedEntry, value, null);
+            EntryEdited?.Invoke(this, EventArgs.Empty);
+        }
+
+        private PropertyInfo GetProperty(string propertyName)
+        {
+            // The editor uses concrete field groups. Reflection here only keeps UndoManager wiring consistent for simple scalar fields.
+            return typeof(BCM_Entry).GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public);
+        }
+
+        private static uint ToUInt32(object value)
+        {
+            if (value == null) return 0;
+            return Convert.ToUInt32(value, CultureInfo.InvariantCulture);
+        }
+
+        private static object FromUInt32(Type type, uint value)
+        {
+            if (type.IsEnum) return Enum.ToObject(type, value);
+            if (type == typeof(uint)) return value;
+            if (type == typeof(ushort)) return (ushort)value;
+            if (type == typeof(short)) return unchecked((short)value);
+            if (type == typeof(int)) return unchecked((int)value);
+            return value;
+        }
+
+        private static bool TryConvertText(string text, Type type, EditorValueMode valueMode, out object value)
+        {
+            text = (text ?? string.Empty).Trim();
+
+            if (type == typeof(string))
+            {
+                value = string.IsNullOrWhiteSpace(text) ? null : text;
+                return true;
+            }
+
+            bool isHex = valueMode == EditorValueMode.Hex || text.StartsWith("0x", StringComparison.OrdinalIgnoreCase);
+            string numberText = text.StartsWith("0x", StringComparison.OrdinalIgnoreCase) ? text.Substring(2) : text;
+
+            if (type == typeof(float))
+            {
+                if (float.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out float floatValue))
+                {
+                    value = floatValue;
+                    return true;
+                }
+
+                value = null;
+                return false;
+            }
+
+            if (isHex)
+            {
+                if (!uint.TryParse(numberText, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out uint hexValue))
+                {
+                    value = null;
+                    return false;
+                }
+
+                value = FromUInt32(type, hexValue);
+                return true;
+            }
+
+            if (type == typeof(uint) && uint.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out uint uintValue))
+            {
+                value = uintValue;
+                return true;
+            }
+
+            if (type == typeof(ushort) && ushort.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out ushort ushortValue))
+            {
+                value = ushortValue;
+                return true;
+            }
+
+            if (type == typeof(short) && short.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out short shortValue))
+            {
+                value = shortValue;
+                return true;
+            }
+
+            if (type == typeof(int) && int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out int intValue))
+            {
+                value = intValue;
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+
+        private static string FormatValue(object value, EditorValueMode valueMode)
+        {
+            if (value == null) return string.Empty;
+
+            if (valueMode == EditorValueMode.Hex)
+                return $"0x{ToDisplayUInt32(value):X}";
+
+            if (value is float floatValue)
+                return floatValue.ToString("0.#######", CultureInfo.InvariantCulture);
+
+            return Convert.ToString(value, CultureInfo.InvariantCulture);
+        }
+
+        private static uint ToDisplayUInt32(object value)
+        {
+            if (value is short shortValue) return unchecked((ushort)shortValue);
+            if (value is int intValue) return unchecked((uint)intValue);
+            if (value is ushort ushortValue) return ushortValue;
+            if (value is byte byteValue) return byteValue;
+            if (value is sbyte sbyteValue) return unchecked((byte)sbyteValue);
+            return Convert.ToUInt32(value, CultureInfo.InvariantCulture);
+        }
+
+    }
+}

--- a/XenoKit/Views/BCM/BcmEntryEditor.Groups.cs
+++ b/XenoKit/Views/BCM/BcmEntryEditor.Groups.cs
@@ -16,15 +16,16 @@ namespace XenoKit.Views.BCM
             PropertyInfo property = GetProperty(propertyName);
             if (property == null) return;
 
+            BCM_Entry entry = SelectedEntry;
             BcmBitGroupView view = new BcmBitGroupView
             {
                 Title = title,
-                Value = ToUInt32(property.GetValue(SelectedEntry, null))
+                Value = ToUInt32(property.GetValue(entry, null))
             };
             view.SetGroups(groups);
             view.ValueChanged += (sender, args) =>
             {
-                SetProperty(property, FromUInt32(property.PropertyType, view.Value));
+                SetProperty(entry, property, FromUInt32(property.PropertyType, view.Value));
                 if (property.Name == nameof(BCM_Entry.I_00))
                     BuildEditor();
             };
@@ -36,15 +37,16 @@ namespace XenoKit.Views.BCM
             PropertyInfo property = GetProperty(propertyName);
             if (property == null) return;
 
+            BCM_Entry entry = SelectedEntry;
             BcmOptionGroupView view = new BcmOptionGroupView
             {
                 Title = title,
-                Value = ToUInt32(property.GetValue(SelectedEntry, null))
+                Value = ToUInt32(property.GetValue(entry, null))
             };
             view.SetGroups(groups);
             view.ValueChanged += (sender, args) =>
             {
-                SetProperty(property, FromUInt32(property.PropertyType, view.Value));
+                SetProperty(entry, property, FromUInt32(property.PropertyType, view.Value));
                 if (property.Name == nameof(BCM_Entry.I_00))
                     BuildEditor();
             };

--- a/XenoKit/Views/BCM/BcmEntryEditor.Groups.cs
+++ b/XenoKit/Views/BCM/BcmEntryEditor.Groups.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Globalization;
+using System.Reflection;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using Xv2CoreLib.BCM;
+using Xv2CoreLib.Resource.UndoRedo;
+
+namespace XenoKit.Views.BCM
+{
+    public partial class BcmEntryEditor : UserControl
+    {
+        private void AddBitGroup(Panel panel, string title, string propertyName, params BcmChoiceGroup[] groups)
+        {
+            PropertyInfo property = GetProperty(propertyName);
+            if (property == null) return;
+
+            BcmBitGroupView view = new BcmBitGroupView
+            {
+                Title = title,
+                Value = ToUInt32(property.GetValue(SelectedEntry, null))
+            };
+            view.SetGroups(groups);
+            view.ValueChanged += (sender, args) =>
+            {
+                SetProperty(property, FromUInt32(property.PropertyType, view.Value));
+                if (property.Name == nameof(BCM_Entry.I_00))
+                    BuildEditor();
+            };
+            panel.Children.Add(view);
+        }
+
+        private void AddOptionGroup(Panel panel, string title, string propertyName, params BcmOptionGroup[] groups)
+        {
+            PropertyInfo property = GetProperty(propertyName);
+            if (property == null) return;
+
+            BcmOptionGroupView view = new BcmOptionGroupView
+            {
+                Title = title,
+                Value = ToUInt32(property.GetValue(SelectedEntry, null))
+            };
+            view.SetGroups(groups);
+            view.ValueChanged += (sender, args) =>
+            {
+                SetProperty(property, FromUInt32(property.PropertyType, view.Value));
+                if (property.Name == nameof(BCM_Entry.I_00))
+                    BuildEditor();
+            };
+            panel.Children.Add(view);
+        }
+
+        private Grid CreateEditorRow(string labelText)
+        {
+            Grid row = new Grid
+            {
+                Margin = new Thickness(0, 0, 0, 9),
+                HorizontalAlignment = HorizontalAlignment.Stretch
+            };
+            row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(150) });
+            row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
+            TextBlock label = new TextBlock
+            {
+                Text = labelText,
+                ToolTip = labelText,
+                TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(0, 3, 12, 0),
+                VerticalAlignment = VerticalAlignment.Top
+            };
+            label.SetResourceReference(ForegroundProperty, "MahApps.Brushes.Text");
+            Grid.SetColumn(label, 0);
+            row.Children.Add(label);
+
+            return row;
+        }
+
+        private static BcmChoice Choice(string label, object value)
+        {
+            return new BcmChoice(label, Convert.ToUInt32(value, CultureInfo.InvariantCulture));
+        }
+
+    }
+}

--- a/XenoKit/Views/BCM/BcmEntryEditor.SpecialEditors.cs
+++ b/XenoKit/Views/BCM/BcmEntryEditor.SpecialEditors.cs
@@ -1,0 +1,283 @@
+﻿using System;
+using System.Globalization;
+using System.Reflection;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using Xv2CoreLib.BCM;
+using Xv2CoreLib.Resource.UndoRedo;
+
+namespace XenoKit.Views.BCM
+{
+    public partial class BcmEntryEditor : UserControl
+    {
+        private const uint OpponentSizeFamilyMask = 0x000F0000;
+        private const uint OpponentSizeUnknownMask = 0x0000000F;
+        private const uint OpponentSizeUpgradeMask = 0xFF000000;
+
+        private void AddOpponentSizeEditor(Panel panel)
+        {
+            PropertyInfo property = GetProperty(nameof(BCM_Entry.OpponentSizeConditions));
+            if (property == null) return;
+
+            uint currentValue = ToUInt32(property.GetValue(SelectedEntry, null));
+            uint currentSize = currentValue & OpponentSizeFamilyMask;
+            uint currentUnknown = currentValue & OpponentSizeUnknownMask;
+            BcmValueOption[] sizeOptions =
+            {
+                new BcmValueOption("All sizes (0x0)", 0x0),
+                new BcmValueOption("Small characters (0x20000)", 0x20000),
+                new BcmValueOption("Default size (0x40000)", 0x40000),
+                new BcmValueOption("Medium (0x50000)", 0x50000),
+                new BcmValueOption("Medium Large (0x60000)", 0x60000),
+                new BcmValueOption("Large (0x70000)", 0x70000),
+                new BcmValueOption("Great Ape (0x80000)", 0x80000)
+            };
+            BcmValueOption[] unknownOptions =
+            {
+                new BcmValueOption("None (0x0)", 0x0),
+                new BcmValueOption("Unknown (0x1)", 0x1),
+                new BcmValueOption("Unknown (0x3)", 0x3)
+            };
+
+            if (!HasOption(sizeOptions, currentSize))
+            {
+                Array.Resize(ref sizeOptions, sizeOptions.Length + 1);
+                sizeOptions[sizeOptions.Length - 1] = new BcmValueOption($"Unknown size (0x{currentSize:X})", currentSize);
+            }
+
+            if (!HasOption(unknownOptions, currentUnknown))
+            {
+                Array.Resize(ref unknownOptions, unknownOptions.Length + 1);
+                unknownOptions[unknownOptions.Length - 1] = new BcmValueOption($"Unknown (0x{currentUnknown:X})", currentUnknown);
+            }
+
+            AddOpponentSizeCombo(panel, "Opponent Size", sizeOptions, currentSize, OpponentSizeFamilyMask, "Requirements based on character CMS size entries.");
+            AddOpponentSizeCombo(panel, "Size Unknown", unknownOptions, currentUnknown, OpponentSizeUnknownMask, "Low unknown bits for opponent size conditions.");
+        }
+
+        private void AddOpponentSizeCombo(Panel panel, string label, BcmValueOption[] options, uint selectedValue, uint mask, string toolTip)
+        {
+            Grid row = CreateEditorRow(label);
+            ComboBox comboBox = new ComboBox
+            {
+                ItemsSource = options,
+                DisplayMemberPath = nameof(BcmValueOption.Label),
+                SelectedValuePath = nameof(BcmValueOption.Value),
+                SelectedValue = selectedValue,
+                MinWidth = 100,
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                ToolTip = toolTip
+            };
+            comboBox.SelectionChanged += (sender, args) =>
+            {
+                if (comboBox.SelectedValue is uint comboValue)
+                    SetOpponentSizeBits(mask, comboValue);
+            };
+
+            Grid.SetColumn(comboBox, 1);
+            row.Children.Add(comboBox);
+            panel.Children.Add(row);
+        }
+
+        private static bool HasOption(BcmValueOption[] options, uint value)
+        {
+            foreach (BcmValueOption option in options)
+            {
+                if (option.Value == value)
+                    return true;
+            }
+
+            return false;
+        }
+
+        private void SetOpponentSizeBits(uint mask, uint value)
+        {
+            PropertyInfo property = GetProperty(nameof(BCM_Entry.OpponentSizeConditions));
+            if (property == null) return;
+
+            uint currentValue = ToUInt32(property.GetValue(SelectedEntry, null));
+            uint newValue = (currentValue & ~mask) | (value & mask);
+            SetProperty(property, newValue);
+        }
+
+        private void AddReceiverLinkEditor(Panel panel)
+        {
+            PropertyInfo property = GetProperty(nameof(BCM_Entry.ReceiverLinkID));
+            if (property == null) return;
+
+            uint currentValue = ToUInt32(property.GetValue(SelectedEntry, null));
+            BcmValueOption[] options =
+            {
+                new BcmValueOption("None (0x0)", 0x0),
+                new BcmValueOption("Combos (0x1)", 0x1),
+                new BcmValueOption("Supers (0x2)", 0x2),
+                new BcmValueOption("Ultimate / Awoken / Evasive (0x4)", 0x4),
+                new BcmValueOption("Z-Vanish (0x8)", 0x8),
+                new BcmValueOption("Ki Blasts (0x10)", 0x10),
+                new BcmValueOption("Jump (0x20)", 0x20),
+                new BcmValueOption("Guard (0x40)", 0x40),
+                new BcmValueOption("Flying / Step Dash (0x80)", 0x80)
+            };
+
+            bool hasCurrentValue = false;
+            foreach (BcmValueOption option in options)
+            {
+                if (option.Value == currentValue)
+                {
+                    hasCurrentValue = true;
+                    break;
+                }
+            }
+
+            if (!hasCurrentValue)
+            {
+                Array.Resize(ref options, options.Length + 1);
+                options[options.Length - 1] = new BcmValueOption($"Unknown (0x{currentValue:X})", currentValue);
+            }
+
+            Grid row = CreateEditorRow("Receiver Link Id");
+            ComboBox comboBox = new ComboBox
+            {
+                ItemsSource = options,
+                DisplayMemberPath = nameof(BcmValueOption.Label),
+                SelectedValuePath = nameof(BcmValueOption.Value),
+                SelectedValue = currentValue,
+                MinWidth = 100,
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                ToolTip = "Matches the BCM Callback link value. Combos = 0x1, Supers = 0x2, Ultimate / Awoken / Evasive = 0x4."
+            };
+            comboBox.SelectionChanged += (sender, args) =>
+            {
+                if (comboBox.SelectedValue is uint selectedValue)
+                    SetProperty(property, selectedValue);
+            };
+
+            Grid.SetColumn(comboBox, 1);
+            row.Children.Add(comboBox);
+            panel.Children.Add(row);
+        }
+
+        private void AddLinkEditor(Panel panel, string labelText, string propertyName, string structuralIndex)
+        {
+            PropertyInfo property = GetProperty(propertyName);
+            if (property == null) return;
+
+            // The shown value starts from the real tree link. A loop override is only written when the user changes it.
+            string loopIndex = property.GetValue(SelectedEntry, null) as string;
+            string fallbackIndex = NormalizeLinkIndex(structuralIndex);
+            string displayValue = NormalizeLinkIndex(loopIndex);
+            if (displayValue == "0")
+                displayValue = fallbackIndex;
+
+            Grid row = CreateEditorRow(labelText);
+
+            TextBox textBox = new TextBox
+            {
+                MinWidth = 100,
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                Text = displayValue,
+                ToolTip = labelText
+            };
+            textBox.LostFocus += (sender, args) => ApplyLinkValue(textBox, property, fallbackIndex);
+            textBox.TextChanged += (sender, args) => ApplyLinkValue(textBox, property, fallbackIndex, false);
+            textBox.KeyDown += (sender, args) =>
+            {
+                if (args.Key == Key.Enter)
+                {
+                    ApplyLinkValue(textBox, property, fallbackIndex);
+                    args.Handled = true;
+                }
+            };
+
+            Grid.SetColumn(textBox, 1);
+            row.Children.Add(textBox);
+            panel.Children.Add(row);
+        }
+
+        private void ApplyLinkValue(TextBox textBox, PropertyInfo property, string structuralIndex, bool updateText = true)
+        {
+            string value = NormalizeLinkIndex(textBox.Text);
+            string fallbackIndex = NormalizeLinkIndex(structuralIndex);
+            string loopValue = value == fallbackIndex ? null : value;
+            object oldValue = property.GetValue(SelectedEntry, null);
+
+            if (Equals(oldValue, loopValue)) return;
+
+            UndoManager.Instance.AddUndo(new UndoablePropertyGeneric(property.Name, SelectedEntry, oldValue, loopValue, property.Name));
+            property.SetValue(SelectedEntry, loopValue, null);
+            EntryEdited?.Invoke(this, EventArgs.Empty);
+
+            if (updateText)
+                textBox.Text = value;
+        }
+
+        private static string NormalizeLinkIndex(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return "0";
+            return value.Trim();
+        }
+
+        private void AddUpgradeLevelEditor(Panel panel)
+        {
+            Grid row = new Grid
+            {
+                Margin = new Thickness(0, 0, 0, 9),
+                HorizontalAlignment = HorizontalAlignment.Stretch
+            };
+            row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(150) });
+            row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+
+            TextBlock label = new TextBlock
+            {
+                Text = "Upgrade Level",
+                ToolTip = "Opponent Size Conditions mapped as 0x1000000 per level.",
+                TextWrapping = TextWrapping.Wrap,
+                Margin = new Thickness(0, 3, 12, 0),
+                VerticalAlignment = VerticalAlignment.Top
+            };
+            label.SetResourceReference(ForegroundProperty, "MahApps.Brushes.Text");
+            Grid.SetColumn(label, 0);
+            row.Children.Add(label);
+
+            TextBox textBox = new TextBox
+            {
+                MinWidth = 100,
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                Text = GetOpponentSizeUpgradeLevel().ToString(CultureInfo.InvariantCulture),
+                ToolTip = "Level 0 = 0x0, Level 4 = 0x4000000"
+            };
+            textBox.LostFocus += (sender, args) => ApplyUpgradeLevel(textBox);
+            textBox.KeyDown += (sender, args) =>
+            {
+                if (args.Key == Key.Enter)
+                {
+                    ApplyUpgradeLevel(textBox);
+                    args.Handled = true;
+                }
+            };
+
+            Grid.SetColumn(textBox, 1);
+            row.Children.Add(textBox);
+            panel.Children.Add(row);
+        }
+
+        private void ApplyUpgradeLevel(TextBox textBox)
+        {
+            if (!uint.TryParse(textBox.Text, NumberStyles.Integer, CultureInfo.InvariantCulture, out uint level))
+            {
+                textBox.Text = GetOpponentSizeUpgradeLevel().ToString(CultureInfo.InvariantCulture);
+                return;
+            }
+
+            SetOpponentSizeBits(OpponentSizeUpgradeMask, (level << 24) & OpponentSizeUpgradeMask);
+            textBox.Text = level.ToString(CultureInfo.InvariantCulture);
+        }
+
+        private uint GetOpponentSizeUpgradeLevel()
+        {
+            return (SelectedEntry.OpponentSizeConditions & OpponentSizeUpgradeMask) >> 24;
+        }
+
+    }
+}

--- a/XenoKit/Views/BCM/BcmEntryEditor.SpecialEditors.cs
+++ b/XenoKit/Views/BCM/BcmEntryEditor.SpecialEditors.cs
@@ -20,7 +20,8 @@ namespace XenoKit.Views.BCM
             PropertyInfo property = GetProperty(nameof(BCM_Entry.OpponentSizeConditions));
             if (property == null) return;
 
-            uint currentValue = ToUInt32(property.GetValue(SelectedEntry, null));
+            BCM_Entry entry = SelectedEntry;
+            uint currentValue = ToUInt32(property.GetValue(entry, null));
             uint currentSize = currentValue & OpponentSizeFamilyMask;
             uint currentUnknown = currentValue & OpponentSizeUnknownMask;
             BcmValueOption[] sizeOptions =
@@ -52,11 +53,11 @@ namespace XenoKit.Views.BCM
                 unknownOptions[unknownOptions.Length - 1] = new BcmValueOption($"Unknown (0x{currentUnknown:X})", currentUnknown);
             }
 
-            AddOpponentSizeCombo(panel, "Opponent Size", sizeOptions, currentSize, OpponentSizeFamilyMask, "Requirements based on character CMS size entries.");
-            AddOpponentSizeCombo(panel, "Size Unknown", unknownOptions, currentUnknown, OpponentSizeUnknownMask, "Low unknown bits for opponent size conditions.");
+            AddOpponentSizeCombo(panel, entry, "Opponent Size", sizeOptions, currentSize, OpponentSizeFamilyMask, "Requirements based on character CMS size entries.");
+            AddOpponentSizeCombo(panel, entry, "Size Unknown", unknownOptions, currentUnknown, OpponentSizeUnknownMask, "Low unknown bits for opponent size conditions.");
         }
 
-        private void AddOpponentSizeCombo(Panel panel, string label, BcmValueOption[] options, uint selectedValue, uint mask, string toolTip)
+        private void AddOpponentSizeCombo(Panel panel, BCM_Entry entry, string label, BcmValueOption[] options, uint selectedValue, uint mask, string toolTip)
         {
             Grid row = CreateEditorRow(label);
             ComboBox comboBox = new ComboBox
@@ -72,7 +73,7 @@ namespace XenoKit.Views.BCM
             comboBox.SelectionChanged += (sender, args) =>
             {
                 if (comboBox.SelectedValue is uint comboValue)
-                    SetOpponentSizeBits(mask, comboValue);
+                    SetOpponentSizeBits(entry, mask, comboValue);
             };
 
             Grid.SetColumn(comboBox, 1);
@@ -91,14 +92,14 @@ namespace XenoKit.Views.BCM
             return false;
         }
 
-        private void SetOpponentSizeBits(uint mask, uint value)
+        private void SetOpponentSizeBits(BCM_Entry entry, uint mask, uint value)
         {
             PropertyInfo property = GetProperty(nameof(BCM_Entry.OpponentSizeConditions));
             if (property == null) return;
 
-            uint currentValue = ToUInt32(property.GetValue(SelectedEntry, null));
+            uint currentValue = ToUInt32(property.GetValue(entry, null));
             uint newValue = (currentValue & ~mask) | (value & mask);
-            SetProperty(property, newValue);
+            SetProperty(entry, property, newValue);
         }
 
         private void AddReceiverLinkEditor(Panel panel)
@@ -106,7 +107,8 @@ namespace XenoKit.Views.BCM
             PropertyInfo property = GetProperty(nameof(BCM_Entry.ReceiverLinkID));
             if (property == null) return;
 
-            uint currentValue = ToUInt32(property.GetValue(SelectedEntry, null));
+            BCM_Entry entry = SelectedEntry;
+            uint currentValue = ToUInt32(property.GetValue(entry, null));
             BcmValueOption[] options =
             {
                 new BcmValueOption("None (0x0)", 0x0),
@@ -150,7 +152,7 @@ namespace XenoKit.Views.BCM
             comboBox.SelectionChanged += (sender, args) =>
             {
                 if (comboBox.SelectedValue is uint selectedValue)
-                    SetProperty(property, selectedValue);
+                    SetProperty(entry, property, selectedValue);
             };
 
             Grid.SetColumn(comboBox, 1);
@@ -163,8 +165,9 @@ namespace XenoKit.Views.BCM
             PropertyInfo property = GetProperty(propertyName);
             if (property == null) return;
 
+            BCM_Entry entry = SelectedEntry;
             // The shown value starts from the real tree link. A loop override is only written when the user changes it.
-            string loopIndex = property.GetValue(SelectedEntry, null) as string;
+            string loopIndex = property.GetValue(entry, null) as string;
             string fallbackIndex = NormalizeLinkIndex(structuralIndex);
             string displayValue = NormalizeLinkIndex(loopIndex);
             if (displayValue == "0")
@@ -179,33 +182,35 @@ namespace XenoKit.Views.BCM
                 Text = displayValue,
                 ToolTip = labelText
             };
-            textBox.LostFocus += (sender, args) => ApplyLinkValue(textBox, property, fallbackIndex);
-            textBox.TextChanged += (sender, args) => ApplyLinkValue(textBox, property, fallbackIndex, false);
+            textBox.LostFocus += (sender, args) => ApplyLinkValue(textBox, entry, property, fallbackIndex);
+            textBox.TextChanged += (sender, args) => ApplyLinkValue(textBox, entry, property, fallbackIndex, false);
             textBox.KeyDown += (sender, args) =>
             {
                 if (args.Key == Key.Enter)
                 {
-                    ApplyLinkValue(textBox, property, fallbackIndex);
+                    ApplyLinkValue(textBox, entry, property, fallbackIndex);
                     args.Handled = true;
                 }
             };
+
+            pendingCommits.Add(() => ApplyLinkValue(textBox, entry, property, fallbackIndex, false));
 
             Grid.SetColumn(textBox, 1);
             row.Children.Add(textBox);
             panel.Children.Add(row);
         }
 
-        private void ApplyLinkValue(TextBox textBox, PropertyInfo property, string structuralIndex, bool updateText = true)
+        private void ApplyLinkValue(TextBox textBox, BCM_Entry entry, PropertyInfo property, string structuralIndex, bool updateText = true)
         {
             string value = NormalizeLinkIndex(textBox.Text);
             string fallbackIndex = NormalizeLinkIndex(structuralIndex);
             string loopValue = value == fallbackIndex ? null : value;
-            object oldValue = property.GetValue(SelectedEntry, null);
+            object oldValue = property.GetValue(entry, null);
 
             if (Equals(oldValue, loopValue)) return;
 
-            UndoManager.Instance.AddUndo(new UndoablePropertyGeneric(property.Name, SelectedEntry, oldValue, loopValue, property.Name));
-            property.SetValue(SelectedEntry, loopValue, null);
+            UndoManager.Instance.AddUndo(new UndoablePropertyGeneric(property.Name, entry, oldValue, loopValue, property.Name));
+            property.SetValue(entry, loopValue, null);
             EntryEdited?.Invoke(this, EventArgs.Empty);
 
             if (updateText)
@@ -220,6 +225,7 @@ namespace XenoKit.Views.BCM
 
         private void AddUpgradeLevelEditor(Panel panel)
         {
+            BCM_Entry entry = SelectedEntry;
             Grid row = new Grid
             {
                 Margin = new Thickness(0, 0, 0, 9),
@@ -244,39 +250,42 @@ namespace XenoKit.Views.BCM
             {
                 MinWidth = 100,
                 HorizontalAlignment = HorizontalAlignment.Stretch,
-                Text = GetOpponentSizeUpgradeLevel().ToString(CultureInfo.InvariantCulture),
+                Text = GetOpponentSizeUpgradeLevel(entry).ToString(CultureInfo.InvariantCulture),
                 ToolTip = "Level 0 = 0x0, Level 4 = 0x4000000"
             };
-            textBox.LostFocus += (sender, args) => ApplyUpgradeLevel(textBox);
+            textBox.LostFocus += (sender, args) => ApplyUpgradeLevel(textBox, entry);
             textBox.KeyDown += (sender, args) =>
             {
                 if (args.Key == Key.Enter)
                 {
-                    ApplyUpgradeLevel(textBox);
+                    ApplyUpgradeLevel(textBox, entry);
                     args.Handled = true;
                 }
             };
+
+            pendingCommits.Add(() => ApplyUpgradeLevel(textBox, entry, false));
 
             Grid.SetColumn(textBox, 1);
             row.Children.Add(textBox);
             panel.Children.Add(row);
         }
 
-        private void ApplyUpgradeLevel(TextBox textBox)
+        private void ApplyUpgradeLevel(TextBox textBox, BCM_Entry entry, bool updateText = true)
         {
             if (!uint.TryParse(textBox.Text, NumberStyles.Integer, CultureInfo.InvariantCulture, out uint level))
             {
-                textBox.Text = GetOpponentSizeUpgradeLevel().ToString(CultureInfo.InvariantCulture);
+                textBox.Text = GetOpponentSizeUpgradeLevel(entry).ToString(CultureInfo.InvariantCulture);
                 return;
             }
 
-            SetOpponentSizeBits(OpponentSizeUpgradeMask, (level << 24) & OpponentSizeUpgradeMask);
-            textBox.Text = level.ToString(CultureInfo.InvariantCulture);
+            SetOpponentSizeBits(entry, OpponentSizeUpgradeMask, (level << 24) & OpponentSizeUpgradeMask);
+            if (updateText)
+                textBox.Text = level.ToString(CultureInfo.InvariantCulture);
         }
 
-        private uint GetOpponentSizeUpgradeLevel()
+        private uint GetOpponentSizeUpgradeLevel(BCM_Entry entry)
         {
-            return (SelectedEntry.OpponentSizeConditions & OpponentSizeUpgradeMask) >> 24;
+            return (entry.OpponentSizeConditions & OpponentSizeUpgradeMask) >> 24;
         }
 
     }

--- a/XenoKit/Views/BCM/BcmEntryEditor.Tabs.cs
+++ b/XenoKit/Views/BCM/BcmEntryEditor.Tabs.cs
@@ -1,0 +1,216 @@
+﻿using System;
+using System.Globalization;
+using System.Reflection;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using Xv2CoreLib.BCM;
+using Xv2CoreLib.Resource.UndoRedo;
+
+namespace XenoKit.Views.BCM
+{
+    public partial class BcmEntryEditor : UserControl
+    {
+        private void BuildInputsTab()
+        {
+            AddBitGroup(inputsPanel, "Directional Input", nameof(BCM_Entry.DirectionalInput),
+                new BcmChoiceGroup("User Direction",
+                    Choice("Input activated once", DirectionalInput.SingleActivation),
+                    Choice("Up", DirectionalInput.Up),
+                    Choice("Down", DirectionalInput.Down),
+                    Choice("Left", DirectionalInput.Left),
+                    Choice("Right", DirectionalInput.Right)),
+                new BcmChoiceGroup("Actor Direction",
+                    Choice("Forwards", DirectionalInput.Forward),
+                    Choice("Backwards", DirectionalInput.Backwards),
+                    Choice("Left", DirectionalInput.LeftRelative),
+                    Choice("Right", DirectionalInput.RightRelative)));
+
+            AddBitGroup(inputsPanel, "Button Input", nameof(BCM_Entry.ButtonInput),
+                new BcmChoiceGroup(string.Empty,
+                    Choice("Lock On", ButtonInput.LockOn),
+                    Choice("Descend", ButtonInput.Descend),
+                    Choice("Dragon Radar", ButtonInput.DragonRadar),
+                    Choice("Jump 2", ButtonInput.Jump_2),
+                    Choice("Ultimate Menu", ButtonInput.UltimateMenu),
+                    Choice("Skill Input", ButtonInput.SkillInput),
+                    Choice("Super Menu Plus Skill Input", ButtonInput.SuperMenuPlusSkillInput),
+                    Choice("Ultimate Menu Plus Skill Input", ButtonInput.UltimateMenuPlusSkillInput),
+                    Choice("Unk20", ButtonInput.Unk20),
+                    Choice("Ultimate Skill1", ButtonInput.UltimateSkill1),
+                    Choice("Ultimate Skill2", ButtonInput.UltimateSkill2),
+                    Choice("Awoken Skill", ButtonInput.AwokenSkill),
+                    Choice("Evasive Skill", ButtonInput.EvasiveSkill),
+                    Choice("Super Skill1", ButtonInput.SuperSkill1),
+                    Choice("Super Skill2", ButtonInput.SuperSkill2),
+                    Choice("Super Skill3", ButtonInput.SuperSkill3),
+                    Choice("Super Skill4", ButtonInput.SuperSkill4),
+                    Choice("Skill Menu", ButtonInput.SkillMenu),
+                    Choice("Boost", ButtonInput.Boost),
+                    Choice("Guard", ButtonInput.Guard),
+                    Choice("Unk8", ButtonInput.Unk8),
+                    Choice("Light", ButtonInput.Light),
+                    Choice("Heavy", ButtonInput.Heavy),
+                    Choice("Blast", ButtonInput.Blast),
+                    Choice("Jump", ButtonInput.Jump),
+                    Choice("Unk26", ButtonInput.Unk26),
+                    Choice("Unk27", ButtonInput.Unk27),
+                    Choice("Unk28", ButtonInput.Unk28),
+                    Choice("Ultimate Menu 2", ButtonInput.UltimateMenu_2),
+                    Choice("Unk30", ButtonInput.Unk30),
+                    Choice("Unk31", ButtonInput.Unk31),
+                    Choice("Unk32", ButtonInput.Unk32)));
+
+            AddOptionGroup(inputsPanel, "Hold Down Conditions", nameof(BCM_Entry.HoldDownConditions),
+                new BcmOptionGroup("Charge Type", 0x00030000, 16,
+                    new BcmChoice("Automatic", 0),
+                    new BcmChoice("Manual", 1),
+                    new BcmChoice("Hold down to loop", 2),
+                    new BcmChoice("Unknown (0x3)", 3)),
+                new BcmOptionGroup("Options #2", 0x0000F000, 12,
+                    new BcmChoice("Unknown (0x0)", 0),
+                    new BcmChoice("Unknown (0x1)", 1),
+                    new BcmChoice("Unknown (0x2)", 2),
+                    new BcmChoice("Unknown (0x3)", 3)),
+                new BcmOptionGroup("Options #3", 0x00000F00, 8,
+                    new BcmChoice("Unknown (0x0)", 0),
+                    new BcmChoice("Unknown (0x1)", 1),
+                    new BcmChoice("Unknown (0x2)", 2),
+                    new BcmChoice("Unknown (0x3)", 3)),
+                new BcmOptionGroup("Options #4", 0x000000F0, 4,
+                    new BcmChoice("Unknown (0x0)", 0),
+                    new BcmChoice("Unknown (0x1)", 1),
+                    new BcmChoice("Unknown (0x2)", 2),
+                    new BcmChoice("Unknown (0x3)", 3)),
+                new BcmOptionGroup("Behaviour", 0x0000000F, 0,
+                    new BcmChoice("Continue until released", 0),
+                    new BcmChoice("Delay until released", 1),
+                    new BcmChoice("Unknown (0x2)", 2),
+                    new BcmChoice("Stop skill from activating", 4)));
+        }
+
+        private void BuildActivatorTab()
+        {
+            AddOptionGroup(activatorPanel, "Mode", nameof(BCM_Entry.I_00),
+                new BcmOptionGroup("Mode", 0xFFFF, 0,
+                    new BcmChoice("None", 0),
+                    new BcmChoice("Use Skill Upgrades", 1),
+                    new BcmChoice("Opponent Reached Ground", 0x10),
+                    new BcmChoice("Unknown (0x2)", 0x2),
+                    new BcmChoice("Unknown (0x4)", 0x4),
+                    new BcmChoice("Unknown (0x8)", 0x8)));
+
+            if (SelectedEntry.I_00 == 1)
+                AddUpgradeLevelEditor(activatorPanel);
+            else
+                AddOpponentSizeEditor(activatorPanel);
+
+            AddEditor(activatorPanel, "Minimum Loop Duration", nameof(BCM_Entry.MinimumLoopDuration), EditorValueMode.Decimal);
+            AddEditor(activatorPanel, "Maximum Loop Duration", nameof(BCM_Entry.MaximumLoopDuration), EditorValueMode.Decimal);
+
+            Panel callbackFields = AddEditorGroup(activatorPanel, "BCM Callback");
+            AddReceiverLinkEditor(callbackFields);
+
+            Panel resourceFields = AddEditorGroup(activatorPanel, "Resource");
+            AddEditor(resourceFields, "Ki Cost", nameof(BCM_Entry.I_64), EditorValueMode.Decimal);
+            AddEditor(resourceFields, "Stamina Cost", nameof(BCM_Entry.StaminaCost), EditorValueMode.Decimal);
+            AddEditor(resourceFields, "Ki Required", nameof(BCM_Entry.KiRequired), EditorValueMode.Decimal);
+            AddEditor(resourceFields, "Health Required", nameof(BCM_Entry.HealthRequired), EditorValueMode.Decimal);
+
+            Panel userStateFields = AddEditorGroup(activatorPanel, "User State");
+            AddEditor(userStateFields, "CUS Aura", nameof(BCM_Entry.CusAura), EditorValueMode.Decimal);
+            AddEditor(userStateFields, "Transformation Stage", nameof(BCM_Entry.TransStage), EditorValueMode.Decimal);
+
+            AddBitGroup(activatorPanel, "Primary Conditions", nameof(BCM_Entry.PrimaryActivatorConditions),
+                new BcmChoiceGroup("Opponent State",
+                    Choice("Health < 25%", PrimaryActivatorConditions.TargetsHealthLessThan25),
+                    Choice("In Knockback", PrimaryActivatorConditions.OpponentKnockback),
+                    Choice("Being Targeted", PrimaryActivatorConditions.TargetingOpponent)),
+                new BcmChoiceGroup("BAC Callback",
+                    Choice("When an attack hits", PrimaryActivatorConditions.OnAttackHit),
+                    Choice("Running BAC Entry attack Hits", PrimaryActivatorConditions.CurrentBacEntryHits),
+                    new BcmChoice("Pass when Guarding", (uint)PrimaryActivatorConditions.AttackBlocked, "When this is active, the BCM condition \"Attack hit\" or \"Running BAC Entry Attack hit\" pass even when opponent is guarding."),
+                    Choice("Active Projectile", PrimaryActivatorConditions.ActiveProjectile)),
+                new BcmChoiceGroup("User State",
+                    Choice("User's Health < 25% (One Use)", PrimaryActivatorConditions.UsersHealth_OneUse),
+                    Choice("User's Health < 25%", PrimaryActivatorConditions.UsersHealth),
+                    Choice("Transformed", PrimaryActivatorConditions.InTransformedState),
+                    Choice("Base form", PrimaryActivatorConditions.InBaseForm),
+                    Choice("Not Moving", PrimaryActivatorConditions.Idle),
+                    Choice("Flash on/off unless targeting", PrimaryActivatorConditions.Unk10)),
+                new BcmChoiceGroup("Position",
+                    Choice("Standing", PrimaryActivatorConditions.Standing),
+                    Choice("Floating", PrimaryActivatorConditions.Floating),
+                    Choice("Touching \"ground\"", PrimaryActivatorConditions.TouchingGround),
+                    Choice("Close to opponent", PrimaryActivatorConditions.CloseToTarget),
+                    Choice("Far from opponent", PrimaryActivatorConditions.FarFromTarget),
+                    Choice("Not near map ceiling", PrimaryActivatorConditions.NotNearStageCeiling),
+                    Choice("Not near certain objects", PrimaryActivatorConditions.NotNearCertainObjects)),
+                new BcmChoiceGroup("Resource",
+                    Choice("Stamina > 0%", PrimaryActivatorConditions.StaminaAboveZero),
+                    Choice("Pass when Stamina Reaches 0", PrimaryActivatorConditions.CounterProjectile),
+                    Choice("Ki < 100%", PrimaryActivatorConditions.KiBelow100),
+                    Choice("Ki > 0%", PrimaryActivatorConditions.KiAboveZero)),
+                new BcmChoiceGroup("Counter",
+                    Choice("Counter Melee", PrimaryActivatorConditions.Unk17),
+                    Choice("Counter Projectiles", PrimaryActivatorConditions.Unk18),
+                    Choice("Counter All", PrimaryActivatorConditions.CounterMelee)),
+                new BcmChoiceGroup("Touching",
+                    Choice("Ground", PrimaryActivatorConditions.Ground),
+                    Choice("Opponent", PrimaryActivatorConditions.Opponent)),
+                new BcmChoiceGroup("Unknown",
+                    Choice("Unknown (0x4)", PrimaryActivatorConditions.Unk11),
+                    Choice("Unknown (0x2)", PrimaryActivatorConditions.Unk22),
+                    Choice("Unknown (0x8)", PrimaryActivatorConditions.Unk24)));
+
+            AddBitGroup(activatorPanel, "Activator State", nameof(BCM_Entry.ActivatorState),
+                new BcmChoiceGroup("State",
+                    Choice("Receiving Damage", ActivatorState.ReceivingDamage),
+                    Choice("Jumping", ActivatorState.Jumping),
+                    Choice("Not being damaged", ActivatorState.NotReceivingDamage),
+                    Choice("Target attacking player", ActivatorState.TargetIsAttacking)),
+                new BcmChoiceGroup("Action",
+                    Choice("Idle", ActivatorState.Idle),
+                    Choice("Combo/skill", ActivatorState.Attacking),
+                    Choice("Boosting", ActivatorState.Boosting),
+                    Choice("Guarding", ActivatorState.Guarding)));
+        }
+
+        private void BuildBacTab()
+        {
+            AddEditor(bacPanel, "Primary BAC", nameof(BCM_Entry.BacEntryPrimary), EditorValueMode.Decimal);
+            AddEditor(bacPanel, "Charge BAC", nameof(BCM_Entry.BacEntryCharge), EditorValueMode.Decimal);
+            AddEditor(bacPanel, "User Connect BAC", nameof(BCM_Entry.BacEntryUserConnect), EditorValueMode.Decimal);
+            AddEditor(bacPanel, "Victim Connect BAC", nameof(BCM_Entry.BacEntryVictimConnect), EditorValueMode.Decimal);
+            AddEditor(bacPanel, "Airborne BAC", nameof(BCM_Entry.BacEntryAirborne), EditorValueMode.Decimal);
+            AddEditor(bacPanel, "Targeting Override BAC", nameof(BCM_Entry.BacEntryTargetingOverride), EditorValueMode.Decimal);
+            AddOptionGroup(bacPanel, "Mode", nameof(BCM_Entry.RandomFlag),
+                new BcmOptionGroup("Mode", 0xFFFF, 0,
+                    new BcmChoice("None", 0),
+                    new BcmChoice("Random BAC Entry", 1),
+                    new BcmChoice("No Target Correction", 2),
+                    new BcmChoice("3 Instance Setup", 3),
+                    new BcmChoice("Unknown (0x4)", 4),
+                    new BcmChoice("Unknown (0x6)", 6)));
+        }
+
+        private void BuildMiscTab()
+        {
+            AddLinkEditor(miscPanel, "Sibling Idx", nameof(BCM_Entry.LoopAsSibling), SiblingIndex);
+            AddLinkEditor(miscPanel, "Child Idx", nameof(BCM_Entry.LoopAsChild), ChildIndex);
+        }
+
+        private void BuildUnknownTab()
+        {
+            AddEditor(unknownPanel, "I_00", nameof(BCM_Entry.I_00), EditorValueMode.Hex);
+            AddEditor(unknownPanel, "I_36", nameof(BCM_Entry.I_36), EditorValueMode.Hex);
+            AddEditor(unknownPanel, "I_68", nameof(BCM_Entry.I_68), EditorValueMode.Hex);
+            AddEditor(unknownPanel, "I_72", nameof(BCM_Entry.I_72), EditorValueMode.Hex);
+            AddEditor(unknownPanel, "I_80", nameof(BCM_Entry.I_80), EditorValueMode.Hex);
+            AddEditor(unknownPanel, "I_88", nameof(BCM_Entry.I_88), EditorValueMode.Hex);
+            AddEditor(unknownPanel, "I_104", nameof(BCM_Entry.I_104), EditorValueMode.Hex);
+            AddEditor(unknownPanel, "I_108", nameof(BCM_Entry.I_108), EditorValueMode.Hex);
+        }
+
+    }
+}

--- a/XenoKit/Views/BCM/BcmEntryEditor.ValueTypes.cs
+++ b/XenoKit/Views/BCM/BcmEntryEditor.ValueTypes.cs
@@ -1,0 +1,26 @@
+using System.Windows.Controls;
+
+namespace XenoKit.Views.BCM
+{
+    public partial class BcmEntryEditor : UserControl
+    {
+        private enum EditorValueMode
+        {
+            Decimal,
+            Hex,
+            Text
+        }
+
+        private class BcmValueOption
+        {
+            public string Label { get; }
+            public uint Value { get; }
+
+            public BcmValueOption(string label, uint value)
+            {
+                Label = label;
+                Value = value;
+            }
+        }
+    }
+}

--- a/XenoKit/Views/BCM/BcmEntryEditor.xaml
+++ b/XenoKit/Views/BCM/BcmEntryEditor.xaml
@@ -1,0 +1,41 @@
+<UserControl x:Class="XenoKit.Views.BCM.BcmEntryEditor"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro">
+    <Grid MinWidth="420">
+        <TextBlock x:Name="emptyTextBlock"
+                   Text="Select a child state. Root states cannot be edited."
+                   Foreground="{DynamicResource MahApps.Brushes.Text}"
+                   Margin="10"
+                   TextWrapping="Wrap"
+                   Visibility="Collapsed"/>
+        <Controls:MetroTabControl x:Name="tabControl"
+                                  Style="{DynamicResource UnderlinedTabControl}">
+            <Controls:MetroTabItem Header="Inputs" Controls:HeaderedControlHelper.HeaderFontSize="12">
+                <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                    <StackPanel x:Name="inputsPanel" Margin="10"/>
+                </ScrollViewer>
+            </Controls:MetroTabItem>
+            <Controls:MetroTabItem Header="Activator" Controls:HeaderedControlHelper.HeaderFontSize="12">
+                <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                    <StackPanel x:Name="activatorPanel" Margin="10"/>
+                </ScrollViewer>
+            </Controls:MetroTabItem>
+            <Controls:MetroTabItem Header="BAC" Controls:HeaderedControlHelper.HeaderFontSize="12">
+                <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                    <StackPanel x:Name="bacPanel" Margin="10"/>
+                </ScrollViewer>
+            </Controls:MetroTabItem>
+            <Controls:MetroTabItem Header="Misc" Controls:HeaderedControlHelper.HeaderFontSize="12">
+                <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                    <StackPanel x:Name="miscPanel" Margin="10"/>
+                </ScrollViewer>
+            </Controls:MetroTabItem>
+            <Controls:MetroTabItem Header="Unknown" Controls:HeaderedControlHelper.HeaderFontSize="12">
+                <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                    <StackPanel x:Name="unknownPanel" Margin="10"/>
+                </ScrollViewer>
+            </Controls:MetroTabItem>
+        </Controls:MetroTabControl>
+    </Grid>
+</UserControl>

--- a/XenoKit/Views/BCM/BcmEntryEditor.xaml.cs
+++ b/XenoKit/Views/BCM/BcmEntryEditor.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
 using System.Windows;
@@ -12,6 +13,11 @@ namespace XenoKit.Views.BCM
     public partial class BcmEntryEditor : UserControl
     {
         public event EventHandler EntryEdited;
+
+        // Textbox fields commit on LostFocus. Switching entry rebuilds the editor and tears those
+        // textboxes down before they commit, so any in-progress edit is flushed here against the
+        // entry it was built for before the panels are cleared.
+        private readonly List<Action> pendingCommits = new List<Action>();
 
         public static readonly DependencyProperty SelectedEntryProperty = DependencyProperty.Register(
             nameof(SelectedEntry), typeof(BCM_Entry), typeof(BcmEntryEditor), new PropertyMetadata(null, EntryPropertyChanged));
@@ -62,6 +68,8 @@ namespace XenoKit.Views.BCM
 
         private void BuildEditor()
         {
+            FlushPendingCommits();
+
             inputsPanel.Children.Clear();
             activatorPanel.Children.Clear();
             bacPanel.Children.Clear();
@@ -79,6 +87,16 @@ namespace XenoKit.Views.BCM
             BuildBacTab();
             BuildMiscTab();
             BuildUnknownTab();
+        }
+
+        private void FlushPendingCommits()
+        {
+            if (pendingCommits.Count == 0) return;
+
+            List<Action> commits = new List<Action>(pendingCommits);
+            pendingCommits.Clear();
+            foreach (Action commit in commits)
+                commit();
         }
 
 

--- a/XenoKit/Views/BCM/BcmEntryEditor.xaml.cs
+++ b/XenoKit/Views/BCM/BcmEntryEditor.xaml.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Globalization;
+using System.Reflection;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using Xv2CoreLib.BCM;
+using Xv2CoreLib.Resource.UndoRedo;
+
+namespace XenoKit.Views.BCM
+{
+    public partial class BcmEntryEditor : UserControl
+    {
+        public event EventHandler EntryEdited;
+
+        public static readonly DependencyProperty SelectedEntryProperty = DependencyProperty.Register(
+            nameof(SelectedEntry), typeof(BCM_Entry), typeof(BcmEntryEditor), new PropertyMetadata(null, EntryPropertyChanged));
+
+        public static readonly DependencyProperty IsRootEntryProperty = DependencyProperty.Register(
+            nameof(IsRootEntry), typeof(bool), typeof(BcmEntryEditor), new PropertyMetadata(false, EntryPropertyChanged));
+
+        public static readonly DependencyProperty SiblingIndexProperty = DependencyProperty.Register(
+            nameof(SiblingIndex), typeof(string), typeof(BcmEntryEditor), new PropertyMetadata("0", EntryPropertyChanged));
+
+        public static readonly DependencyProperty ChildIndexProperty = DependencyProperty.Register(
+            nameof(ChildIndex), typeof(string), typeof(BcmEntryEditor), new PropertyMetadata("0", EntryPropertyChanged));
+
+        public BCM_Entry SelectedEntry
+        {
+            get => (BCM_Entry)GetValue(SelectedEntryProperty);
+            set => SetValue(SelectedEntryProperty, value);
+        }
+
+        public bool IsRootEntry
+        {
+            get => (bool)GetValue(IsRootEntryProperty);
+            set => SetValue(IsRootEntryProperty, value);
+        }
+
+        public string SiblingIndex
+        {
+            get => (string)GetValue(SiblingIndexProperty);
+            set => SetValue(SiblingIndexProperty, value);
+        }
+
+        public string ChildIndex
+        {
+            get => (string)GetValue(ChildIndexProperty);
+            set => SetValue(ChildIndexProperty, value);
+        }
+
+        public BcmEntryEditor()
+        {
+            InitializeComponent();
+            BuildEditor();
+        }
+
+        private static void EntryPropertyChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
+        {
+            ((BcmEntryEditor)dependencyObject).BuildEditor();
+        }
+
+        private void BuildEditor()
+        {
+            inputsPanel.Children.Clear();
+            activatorPanel.Children.Clear();
+            bacPanel.Children.Clear();
+            miscPanel.Children.Clear();
+            unknownPanel.Children.Clear();
+
+            bool canEdit = SelectedEntry != null && !IsRootEntry;
+            emptyTextBlock.Visibility = canEdit ? Visibility.Collapsed : Visibility.Visible;
+            tabControl.Visibility = canEdit ? Visibility.Visible : Visibility.Collapsed;
+
+            if (!canEdit) return;
+
+            BuildInputsTab();
+            BuildActivatorTab();
+            BuildBacTab();
+            BuildMiscTab();
+            BuildUnknownTab();
+        }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+        private Panel AddEditorGroup(Panel panel, string title)
+        {
+            GroupBox groupBox = new GroupBox
+            {
+                Header = title,
+                Margin = new Thickness(0, 0, 0, 14),
+                Padding = new Thickness(8)
+            };
+            groupBox.SetResourceReference(ForegroundProperty, "MahApps.Brushes.Text");
+            groupBox.SetResourceReference(BorderBrushProperty, "MahApps.Brushes.Gray.SemiTransparent");
+
+            StackPanel stackPanel = new StackPanel();
+            groupBox.Content = stackPanel;
+            panel.Children.Add(groupBox);
+            return stackPanel;
+        }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    }
+}

--- a/XenoKit/Views/BCM/BcmOptionGroupView.xaml
+++ b/XenoKit/Views/BCM/BcmOptionGroupView.xaml
@@ -1,0 +1,12 @@
+<UserControl x:Class="XenoKit.Views.BCM.BcmOptionGroupView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Name="Root">
+    <GroupBox Header="{Binding ElementName=Root, Path=Title}"
+              Foreground="{DynamicResource MahApps.Brushes.Text}"
+              BorderBrush="{DynamicResource MahApps.Brushes.Gray.SemiTransparent}"
+              Margin="0,0,0,14"
+              Padding="8">
+        <WrapPanel x:Name="groupsPanel"/>
+    </GroupBox>
+</UserControl>

--- a/XenoKit/Views/BCM/BcmOptionGroupView.xaml.cs
+++ b/XenoKit/Views/BCM/BcmOptionGroupView.xaml.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace XenoKit.Views.BCM
+{
+    public partial class BcmOptionGroupView : UserControl
+    {
+        public event EventHandler ValueChanged;
+
+        private readonly List<BcmOptionGroup> groups = new List<BcmOptionGroup>();
+        private bool isRefreshing;
+
+        public static readonly DependencyProperty TitleProperty = DependencyProperty.Register(
+            nameof(Title), typeof(string), typeof(BcmOptionGroupView), new PropertyMetadata(string.Empty));
+
+        public static readonly DependencyProperty ValueProperty = DependencyProperty.Register(
+            nameof(Value), typeof(uint), typeof(BcmOptionGroupView), new PropertyMetadata(0u, ValuePropertyChanged));
+
+        public string Title
+        {
+            get => (string)GetValue(TitleProperty);
+            set => SetValue(TitleProperty, value);
+        }
+
+        public uint Value
+        {
+            get => (uint)GetValue(ValueProperty);
+            set => SetValue(ValueProperty, value);
+        }
+
+        public BcmOptionGroupView()
+        {
+            InitializeComponent();
+        }
+
+        public void SetGroups(IEnumerable<BcmOptionGroup> newGroups)
+        {
+            groups.Clear();
+            groups.AddRange(newGroups ?? Enumerable.Empty<BcmOptionGroup>());
+            BuildGroups();
+            RefreshValue();
+        }
+
+        private static void ValuePropertyChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
+        {
+            ((BcmOptionGroupView)dependencyObject).RefreshValue();
+        }
+
+        private void BuildGroups()
+        {
+            groupsPanel.Children.Clear();
+
+            foreach (BcmOptionGroup group in groups)
+            {
+                bool skipInnerHeader = groups.Count == 1 && string.Equals(group.Title, Title, StringComparison.OrdinalIgnoreCase);
+                FrameworkElement groupContainer;
+                Panel stackPanel = new StackPanel();
+
+                if (skipInnerHeader)
+                {
+                    groupContainer = stackPanel;
+                    groupContainer.Margin = new Thickness(0, 0, 10, 8);
+                }
+                else
+                {
+                    GroupBox groupBox = new GroupBox
+                    {
+                        Header = group.Title,
+                        Tag = group,
+                        Width = 210,
+                        Margin = new Thickness(0, 0, 10, 8),
+                        Padding = new Thickness(6)
+                    };
+                    groupBox.SetResourceReference(ForegroundProperty, "MahApps.Brushes.Text");
+                    groupBox.SetResourceReference(BorderBrushProperty, "MahApps.Brushes.Gray.SemiTransparent");
+                    groupBox.Content = stackPanel;
+                    groupContainer = groupBox;
+                }
+
+                groupContainer.Tag = group;
+
+                string groupName = $"{Title}_{group.Title}_{Guid.NewGuid():N}";
+                foreach (BcmChoice choice in group.Choices)
+                {
+                    RadioButton radioButton = new RadioButton
+                    {
+                        GroupName = groupName,
+                        Tag = choice,
+                        Margin = new Thickness(0, 1, 0, 1),
+                        VerticalContentAlignment = VerticalAlignment.Top,
+                        Content = new TextBlock
+                        {
+                            Text = choice.Label,
+                            TextWrapping = TextWrapping.Wrap,
+                            MaxWidth = 178
+                        }
+                    };
+                    radioButton.Checked += RadioButtonChecked;
+                    stackPanel.Children.Add(radioButton);
+                }
+
+                groupsPanel.Children.Add(groupContainer);
+            }
+        }
+
+        private void RefreshValue()
+        {
+            isRefreshing = true;
+
+            foreach (FrameworkElement groupElement in groupsPanel.Children.OfType<FrameworkElement>())
+            {
+                if (!(groupElement.Tag is BcmOptionGroup group)) continue;
+                Panel panel = groupElement is GroupBox groupBox ? groupBox.Content as Panel : groupElement as Panel;
+                if (panel == null) continue;
+
+                uint groupValue = (Value & group.Mask) >> group.Shift;
+                foreach (RadioButton radioButton in panel.Children.OfType<RadioButton>())
+                {
+                    if (radioButton.Tag is BcmChoice choice)
+                        radioButton.IsChecked = choice.Value == groupValue;
+                }
+            }
+
+            isRefreshing = false;
+        }
+
+        private void RadioButtonChecked(object sender, RoutedEventArgs e)
+        {
+            if (isRefreshing) return;
+            if (!(sender is RadioButton radioButton) || !(radioButton.Tag is BcmChoice choice)) return;
+            FrameworkElement groupElement = FindParentGroupElement(radioButton);
+            if (!(groupElement?.Tag is BcmOptionGroup group)) return;
+
+            uint newValue = Value & ~group.Mask;
+            newValue |= (choice.Value << group.Shift) & group.Mask;
+            SetValueFromControl(newValue);
+        }
+
+        private static FrameworkElement FindParentGroupElement(DependencyObject child)
+        {
+            DependencyObject current = child;
+            while (current != null)
+            {
+                if (current is GroupBox groupBox) return groupBox;
+                if (current is StackPanel stackPanel && stackPanel.Tag is BcmOptionGroup) return stackPanel;
+                current = System.Windows.Media.VisualTreeHelper.GetParent(current);
+            }
+
+            return null;
+        }
+
+        private void SetValueFromControl(uint value)
+        {
+            if (Value == value) return;
+
+            Value = value;
+            ValueChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    public class BcmOptionGroup
+    {
+        public string Title { get; set; }
+        public uint Mask { get; set; }
+        public int Shift { get; set; }
+        public IList<BcmChoice> Choices { get; set; }
+
+        public BcmOptionGroup(string title, uint mask, int shift, params BcmChoice[] choices)
+        {
+            Title = title;
+            Mask = mask;
+            Shift = shift;
+            Choices = choices;
+        }
+    }
+}

--- a/XenoKit/Views/BCM/BcmTreeList.xaml
+++ b/XenoKit/Views/BCM/BcmTreeList.xaml
@@ -1,0 +1,171 @@
+<UserControl x:Class="XenoKit.Views.BCM.BcmTreeList"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Name="Root">
+    <UserControl.Resources>
+        <Style x:Key="BcmTreeLinkButton" TargetType="Button">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Padding" Value="0"/>
+            <Setter Property="HorizontalContentAlignment" Value="Left"/>
+            <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}"/>
+            <Setter Property="ToolTip" Value="{Binding RelativeSource={RelativeSource Self}, Path=Content.Text}"/>
+        </Style>
+        <Style x:Key="BcmTreeExpanderToggle" TargetType="ToggleButton">
+            <Setter Property="Focusable" Value="False"/>
+            <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Accent3}"/>
+            <Setter Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.Accent}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Width" Value="18"/>
+            <Setter Property="Height" Value="18"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ToggleButton">
+                        <Border Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="2"
+                                SnapsToDevicePixels="True">
+                            <TextBlock x:Name="Glyph"
+                                       Text="+"
+                                       FontFamily="Consolas"
+                                       FontSize="15"
+                                       FontWeight="Bold"
+                                       Foreground="{DynamicResource MahApps.Brushes.Text}"
+                                       HorizontalAlignment="Center"
+                                       VerticalAlignment="Center"
+                                       TextAlignment="Center"
+                                       Width="16"
+                                       Height="16"
+                                       LineStackingStrategy="BlockLineHeight"
+                                       LineHeight="16"
+                                       Margin="0,-1,0,0"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsChecked" Value="True">
+                                <Setter TargetName="Glyph" Property="Text" Value="-"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+        <Style x:Key="BcmTreeItemStyle" TargetType="{x:Type TreeViewItem}">
+            <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}"/>
+            <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}"/>
+            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type TreeViewItem}">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="*"/>
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="22"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+
+                            <Border Grid.Row="0"
+                                    Grid.RowSpan="2"
+                                    Grid.Column="0"
+                                    Width="1"
+                                    HorizontalAlignment="Center"
+                                    Background="{DynamicResource MahApps.Brushes.Gray.SemiTransparent}"/>
+                            <Border Grid.Row="0"
+                                    Grid.Column="0"
+                                    Height="1"
+                                    VerticalAlignment="Center"
+                                    Margin="11,0,0,0"
+                                    Background="{DynamicResource MahApps.Brushes.Gray.SemiTransparent}"/>
+                            <ToggleButton x:Name="Expander"
+                                          Grid.Row="0"
+                                          Grid.Column="0"
+                                          Style="{StaticResource BcmTreeExpanderToggle}"
+                                          IsChecked="{Binding IsExpanded, RelativeSource={RelativeSource TemplatedParent}}"/>
+                            <Border x:Name="HeaderBorder"
+                                    Grid.Row="0"
+                                    Grid.Column="1"
+                                    Padding="2,1"
+                                    Background="Transparent">
+                                <ContentPresenter x:Name="PART_Header"
+                                                  ContentSource="Header"
+                                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"/>
+                            </Border>
+                            <ItemsPresenter x:Name="ItemsHost"
+                                            Grid.Row="1"
+                                            Grid.Column="1"/>
+                        </Grid>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="HasItems" Value="False">
+                                <Setter TargetName="Expander" Property="Visibility" Value="Hidden"/>
+                            </Trigger>
+                            <Trigger Property="IsExpanded" Value="False">
+                                <Setter TargetName="ItemsHost" Property="Visibility" Value="Collapsed"/>
+                            </Trigger>
+                            <Trigger Property="IsSelected" Value="True">
+                                <Setter TargetName="HeaderBorder" Property="Background" Value="{DynamicResource MahApps.Brushes.DataGrid.Selection.Background}"/>
+                            </Trigger>
+                            <DataTrigger Binding="{Binding IsSelected}" Value="True">
+                                <Setter TargetName="HeaderBorder" Property="Background" Value="{DynamicResource MahApps.Brushes.DataGrid.Selection.Background}"/>
+                            </DataTrigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </UserControl.Resources>
+
+    <TreeView x:Name="treeView"
+              ItemsSource="{Binding ElementName=Root, Path=RootRows}"
+              ItemContainerStyle="{StaticResource BcmTreeItemStyle}"
+              VirtualizingStackPanel.IsVirtualizing="True"
+              VirtualizingStackPanel.VirtualizationMode="Recycling"
+              ScrollViewer.CanContentScroll="True"
+              BorderBrush="{DynamicResource MahApps.Brushes.Gray.SemiTransparent}"
+              Background="Transparent"
+              Foreground="{DynamicResource MahApps.Brushes.Text}"
+              SelectedItemChanged="TreeView_SelectedItemChanged">
+        <TreeView.Resources>
+            <HierarchicalDataTemplate DataType="{x:Type local:BcmTreeRow}" ItemsSource="{Binding Children}"
+                                      xmlns:local="clr-namespace:XenoKit.Views.BCM">
+                <Grid Margin="0,1" MinWidth="260" PreviewMouseLeftButtonDown="RowHeader_PreviewMouseLeftButtonDown" PreviewMouseRightButtonDown="RowHeader_PreviewMouseRightButtonDown">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="52"/>
+                        <ColumnDefinition Width="74"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Text="{Binding IndexText}"
+                               FontWeight="SemiBold"
+                               TextWrapping="Wrap"
+                               ToolTip="{Binding IndexText}"
+                               Foreground="{DynamicResource MahApps.Brushes.Text}"
+                               Margin="0,0,8,0"/>
+                    <TextBlock Grid.Column="1"
+                               Text="{Binding BacText}"
+                               TextWrapping="Wrap"
+                               ToolTip="{Binding BacText}"
+                               Foreground="{DynamicResource MahApps.Brushes.Text}"
+                               Margin="0,0,8,0"/>
+                    <StackPanel Grid.Column="2">
+                        <Button Style="{StaticResource BcmTreeLinkButton}"
+                                Click="ChildLink_Click"
+                                Visibility="{Binding ChildLinkVisibility}">
+                            <TextBlock Text="{Binding ChildLinkText}"
+                                       TextWrapping="Wrap"
+                                       Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"/>
+                        </Button>
+                        <Button Style="{StaticResource BcmTreeLinkButton}"
+                                Click="SiblingLink_Click"
+                                Visibility="{Binding SiblingLinkVisibility}">
+                            <TextBlock Text="{Binding SiblingLinkText}"
+                                       TextWrapping="Wrap"
+                                       Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"/>
+                        </Button>
+                    </StackPanel>
+                </Grid>
+            </HierarchicalDataTemplate>
+        </TreeView.Resources>
+    </TreeView>
+</UserControl>

--- a/XenoKit/Views/BCM/BcmTreeList.xaml.cs
+++ b/XenoKit/Views/BCM/BcmTreeList.xaml.cs
@@ -1,0 +1,431 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using Xv2CoreLib.BCM;
+
+namespace XenoKit.Views.BCM
+{
+    public partial class BcmTreeList : UserControl, INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private readonly List<BcmTreeRow> allRows = new List<BcmTreeRow>();
+        private readonly Dictionary<string, BcmTreeRow> rowsByIndex = new Dictionary<string, BcmTreeRow>();
+        private bool isSelecting;
+        private BcmTreeRow selectionAnchor;
+
+        public static readonly DependencyProperty EntriesProperty = DependencyProperty.Register(
+            nameof(Entries), typeof(IList), typeof(BcmTreeList), new PropertyMetadata(null, EntriesPropertyChanged));
+
+        public static readonly DependencyProperty SelectedEntryProperty = DependencyProperty.Register(
+            nameof(SelectedEntry), typeof(BCM_Entry), typeof(BcmTreeList), new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, SelectedEntryPropertyChanged));
+
+        public IList Entries
+        {
+            get => (IList)GetValue(EntriesProperty);
+            set => SetValue(EntriesProperty, value);
+        }
+
+        public BCM_Entry SelectedEntry
+        {
+            get => (BCM_Entry)GetValue(SelectedEntryProperty);
+            set => SetValue(SelectedEntryProperty, value);
+        }
+
+        public ObservableCollection<BcmTreeRow> RootRows { get; } = new ObservableCollection<BcmTreeRow>();
+        public ObservableCollection<BCM_Entry> SelectedEntries { get; } = new ObservableCollection<BCM_Entry>();
+        public event EventHandler SelectionChanged;
+
+        public BcmTreeList()
+        {
+            InitializeComponent();
+        }
+
+        public void Refresh()
+        {
+            BuildRows();
+        }
+
+        public void RefreshDisplay()
+        {
+            foreach (BcmTreeRow row in allRows)
+                row.RefreshDisplay();
+        }
+
+        public void SelectEntry(BCM_Entry entry)
+        {
+            SelectRow(allRows.FirstOrDefault(row => ReferenceEquals(row.Entry, entry)), true, true);
+        }
+
+        private static void EntriesPropertyChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
+        {
+            ((BcmTreeList)dependencyObject).BuildRows();
+        }
+
+        private static void SelectedEntryPropertyChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
+        {
+            BcmTreeList treeList = (BcmTreeList)dependencyObject;
+            if (treeList.isSelecting) return;
+
+            treeList.SelectRow(treeList.allRows.FirstOrDefault(row => ReferenceEquals(row.Entry, e.NewValue as BCM_Entry)), false, true);
+        }
+
+        private void BuildRows()
+        {
+            List<BCM_Entry> oldSelections = SelectedEntries.ToList();
+            BCM_Entry oldSelection = SelectedEntry;
+            allRows.Clear();
+            rowsByIndex.Clear();
+            RootRows.Clear();
+            SelectedEntries.Clear();
+
+            foreach (BCM_Entry entry in Entries?.OfType<BCM_Entry>() ?? Enumerable.Empty<BCM_Entry>())
+                RootRows.Add(AddRows(entry, null, 0));
+
+            foreach (BcmTreeRow row in allRows.Where(row => oldSelections.Contains(row.Entry)))
+                row.IsSelected = true;
+
+            SyncSelectedEntries();
+            SelectRow(allRows.FirstOrDefault(row => ReferenceEquals(row.Entry, oldSelection)) ?? allRows.FirstOrDefault(row => row.IsSelected), true, false);
+        }
+
+        private BcmTreeRow AddRows(BCM_Entry entry, BcmTreeRow parent, int depth)
+        {
+            BcmTreeRow row = new BcmTreeRow(entry, parent, depth, GetLinkText);
+            allRows.Add(row);
+            if (!string.IsNullOrWhiteSpace(entry?.Index))
+                rowsByIndex[entry.Index] = row;
+
+            foreach (BCM_Entry child in entry.BCMEntries ?? Enumerable.Empty<BCM_Entry>())
+                row.Children.Add(AddRows(child, row, depth + 1));
+
+            return row;
+        }
+
+        private string GetLinkText(string linkType, string index)
+        {
+            if (string.IsNullOrWhiteSpace(index)) return null;
+
+            rowsByIndex.TryGetValue(index, out BcmTreeRow row);
+            if (row == null) return $"{linkType} {index} | Missing";
+
+            return $"{linkType} {index} | BAC {row.Entry.BacEntryPrimary}";
+        }
+
+        private void TreeView_SelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
+        {
+            if (isSelecting) return;
+
+            SelectRow(e.NewValue as BcmTreeRow, true, true);
+        }
+
+        private void RowHeader_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (!((sender as FrameworkElement)?.DataContext is BcmTreeRow row)) return;
+
+            ModifierKeys modifiers = Keyboard.Modifiers;
+            if ((modifiers & ModifierKeys.Shift) == ModifierKeys.Shift)
+            {
+                SelectRange(row);
+            }
+            else if ((modifiers & ModifierKeys.Control) == ModifierKeys.Control)
+            {
+                ToggleRow(row);
+            }
+            else
+            {
+                SelectRow(row, true, true);
+            }
+
+            FocusTreeItem(row);
+            e.Handled = true;
+        }
+
+        private void RowHeader_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (!((sender as FrameworkElement)?.DataContext is BcmTreeRow row)) return;
+
+            if (!row.IsSelected)
+                SelectRow(row, true, true);
+
+            FocusTreeItem(row);
+
+            e.Handled = true;
+        }
+
+        private void ChildLink_Click(object sender, RoutedEventArgs e)
+        {
+            if ((sender as FrameworkElement)?.DataContext is BcmTreeRow row)
+                SelectLinkedRow(row.Entry?.LoopAsChild);
+
+            e.Handled = true;
+        }
+
+        private void SiblingLink_Click(object sender, RoutedEventArgs e)
+        {
+            if ((sender as FrameworkElement)?.DataContext is BcmTreeRow row)
+                SelectLinkedRow(row.Entry?.LoopAsSibling);
+
+            e.Handled = true;
+        }
+
+        private void SelectLinkedRow(string index)
+        {
+            if (string.IsNullOrWhiteSpace(index)) return;
+
+            rowsByIndex.TryGetValue(index, out BcmTreeRow row);
+            if (row == null) return;
+
+            BcmTreeRow parent = row.Parent;
+            while (parent != null)
+            {
+                parent.IsExpanded = true;
+                parent = parent.Parent;
+            }
+
+            SelectRow(row, true, true);
+        }
+
+        private void SelectRow(BcmTreeRow row, bool updateEntry, bool replaceSelection)
+        {
+            isSelecting = true;
+            if (replaceSelection)
+            {
+                foreach (BcmTreeRow existingRow in allRows)
+                    existingRow.IsSelected = ReferenceEquals(existingRow, row);
+            }
+
+            if (updateEntry)
+                SelectedEntry = row?.Entry;
+            isSelecting = false;
+            selectionAnchor = row ?? selectionAnchor;
+            SyncSelectedEntries();
+
+            if (row != null)
+                treeView.Dispatcher.BeginInvoke(new Action(() => SelectTreeItem(treeView, row)));
+        }
+
+        private void ToggleRow(BcmTreeRow row)
+        {
+            row.IsSelected = !row.IsSelected;
+            if (row.IsSelected)
+            {
+                selectionAnchor = row;
+                SelectRow(row, true, false);
+                return;
+            }
+
+            SyncSelectedEntries();
+            if (ReferenceEquals(SelectedEntry, row.Entry))
+                SelectRow(allRows.FirstOrDefault(existingRow => existingRow.IsSelected), true, false);
+        }
+
+        private void SelectRange(BcmTreeRow row)
+        {
+            List<BcmTreeRow> visibleRows = GetVisibleRows().ToList();
+            BcmTreeRow anchor = selectionAnchor ?? row;
+            int anchorIndex = visibleRows.IndexOf(anchor);
+            int rowIndex = visibleRows.IndexOf(row);
+
+            if (anchorIndex < 0 || rowIndex < 0)
+            {
+                SelectRow(row, true, true);
+                return;
+            }
+
+            int start = Math.Min(anchorIndex, rowIndex);
+            int end = Math.Max(anchorIndex, rowIndex);
+            foreach (BcmTreeRow existingRow in allRows)
+                existingRow.IsSelected = false;
+
+            for (int index = start; index <= end; index++)
+                visibleRows[index].IsSelected = true;
+
+            SelectRow(row, true, false);
+        }
+
+        private IEnumerable<BcmTreeRow> GetVisibleRows()
+        {
+            foreach (BcmTreeRow row in RootRows)
+            {
+                yield return row;
+
+                if (!row.IsExpanded) continue;
+                foreach (BcmTreeRow child in GetVisibleRows(row))
+                    yield return child;
+            }
+        }
+
+        private IEnumerable<BcmTreeRow> GetVisibleRows(BcmTreeRow row)
+        {
+            foreach (BcmTreeRow child in row.Children)
+            {
+                yield return child;
+
+                if (!child.IsExpanded) continue;
+                foreach (BcmTreeRow grandChild in GetVisibleRows(child))
+                    yield return grandChild;
+            }
+        }
+
+        private void SyncSelectedEntries()
+        {
+            SelectedEntries.Clear();
+            foreach (BcmTreeRow row in allRows.Where(row => row.IsSelected))
+                SelectedEntries.Add(row.Entry);
+
+            SelectionChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        private void FocusTreeItem(BcmTreeRow row)
+        {
+            TreeViewItem treeViewItem = FindTreeViewItem(treeView, row);
+            if (treeViewItem == null) return;
+
+            treeViewItem.IsSelected = true;
+            treeViewItem.Focus();
+        }
+
+        private bool SelectTreeItem(ItemsControl parent, BcmTreeRow target)
+        {
+            parent.UpdateLayout();
+
+            foreach (object item in parent.Items)
+            {
+                TreeViewItem treeViewItem = parent.ItemContainerGenerator.ContainerFromItem(item) as TreeViewItem;
+                if (treeViewItem == null) continue;
+
+                if (ReferenceEquals(item, target))
+                {
+                    treeViewItem.IsSelected = true;
+                    treeViewItem.BringIntoView();
+                    treeViewItem.Focus();
+                    return true;
+                }
+
+                BcmTreeRow row = item as BcmTreeRow;
+                if (row != null && ContainsRow(row, target))
+                {
+                    treeViewItem.IsExpanded = true;
+                    if (SelectTreeItem(treeViewItem, target)) return true;
+                }
+            }
+
+            return false;
+        }
+
+        private TreeViewItem FindTreeViewItem(ItemsControl parent, BcmTreeRow target)
+        {
+            parent.UpdateLayout();
+
+            foreach (object item in parent.Items)
+            {
+                TreeViewItem treeViewItem = parent.ItemContainerGenerator.ContainerFromItem(item) as TreeViewItem;
+                if (treeViewItem == null) continue;
+
+                if (ReferenceEquals(item, target))
+                    return treeViewItem;
+
+                BcmTreeRow row = item as BcmTreeRow;
+                if (row != null && ContainsRow(row, target))
+                {
+                    treeViewItem.IsExpanded = true;
+                    TreeViewItem result = FindTreeViewItem(treeViewItem, target);
+                    if (result != null) return result;
+                }
+            }
+
+            return null;
+        }
+
+        private static bool ContainsRow(BcmTreeRow row, BcmTreeRow target)
+        {
+            foreach (BcmTreeRow child in row.Children)
+            {
+                if (ReferenceEquals(child, target)) return true;
+                if (ContainsRow(child, target)) return true;
+            }
+
+            return false;
+        }
+
+        private void NotifyPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+
+    public class BcmTreeRow : INotifyPropertyChanged
+    {
+        private readonly Func<string, string, string> getLinkText;
+        private bool isExpanded;
+        private bool isSelected;
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public BCM_Entry Entry { get; }
+        public BcmTreeRow Parent { get; }
+        public ObservableCollection<BcmTreeRow> Children { get; } = new ObservableCollection<BcmTreeRow>();
+        public int Depth { get; }
+
+        public bool IsExpanded
+        {
+            get => isExpanded;
+            set
+            {
+                if (isExpanded == value) return;
+                isExpanded = value;
+                NotifyPropertyChanged(nameof(IsExpanded));
+            }
+        }
+
+        public bool IsSelected
+        {
+            get => isSelected;
+            set
+            {
+                if (isSelected == value) return;
+                isSelected = value;
+                NotifyPropertyChanged(nameof(IsSelected));
+            }
+        }
+
+        public string IndexText => Entry?.Index ?? string.Empty;
+        public string BacText => $"BAC {Entry?.BacEntryPrimary ?? 0}";
+        public string ChildLinkText => getLinkText("Child", Entry?.LoopAsChild);
+        public string SiblingLinkText => getLinkText("Sibling", Entry?.LoopAsSibling);
+        public Visibility ChildLinkVisibility => string.IsNullOrWhiteSpace(ChildLinkText) ? Visibility.Collapsed : Visibility.Visible;
+        public Visibility SiblingLinkVisibility => string.IsNullOrWhiteSpace(SiblingLinkText) ? Visibility.Collapsed : Visibility.Visible;
+
+        public BcmTreeRow(BCM_Entry entry, BcmTreeRow parent, int depth, Func<string, string, string> getLinkText)
+        {
+            Entry = entry;
+            Parent = parent;
+            Depth = depth;
+            this.getLinkText = getLinkText;
+            isExpanded = depth == 0;
+        }
+
+        public void RefreshDisplay()
+        {
+            NotifyPropertyChanged(nameof(IndexText));
+            NotifyPropertyChanged(nameof(BacText));
+            NotifyPropertyChanged(nameof(ChildLinkText));
+            NotifyPropertyChanged(nameof(SiblingLinkText));
+            NotifyPropertyChanged(nameof(ChildLinkVisibility));
+            NotifyPropertyChanged(nameof(SiblingLinkVisibility));
+        }
+
+        private void NotifyPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/XenoKit/Views/BcmTab.xaml
+++ b/XenoKit/Views/BcmTab.xaml
@@ -1,0 +1,130 @@
+<UserControl x:Class="XenoKit.Views.BcmTab"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:Dialog="clr-namespace:MahApps.Metro.Controls.Dialogs;assembly=MahApps.Metro"
+             xmlns:iconPacks="http://metro.mahapps.com/winfx/xaml/iconpacks"
+             xmlns:editor="clr-namespace:XenoKit.Editor"
+             xmlns:bcmViews="clr-namespace:XenoKit.Views.BCM"
+             Dialog:DialogParticipation.Register="{Binding}"
+             mc:Ignorable="d"
+             d:DesignHeight="620" d:DesignWidth="980"
+             x:Name="UserControl">
+    <UserControl.Resources>
+        <Style x:Key="BcmToolButton" TargetType="Button" BasedOn="{StaticResource MahApps.Styles.Button.Circle}">
+            <Setter Property="Width" Value="30"/>
+            <Setter Property="Height" Value="30"/>
+            <Setter Property="HorizontalAlignment" Value="Center"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="Padding" Value="0"/>
+        </Style>
+        <Style x:Key="BcmToolLabel" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="8"/>
+            <Setter Property="HorizontalAlignment" Value="Center"/>
+            <Setter Property="TextAlignment" Value="Center"/>
+            <Setter Property="Margin" Value="0,1,0,7"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+            <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}"/>
+        </Style>
+    </UserControl.Resources>
+
+    <Grid Margin="8">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <DockPanel Grid.Row="0" LastChildFill="False" Margin="0,0,0,8">
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="State file" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                <ComboBox SelectedItem="{Binding Source={x:Static editor:Files.Instance}, Path=SelectedItem.SelectedBcmFile}"
+                          ItemsSource="{Binding BcmFiles}"
+                          DisplayMemberPath="DisplayName"
+                          Visibility="{Binding BcmFileSelectorVisibility}"
+                          SelectionChanged="BcmFileSelection_Changed"
+                          Height="26"
+                          Width="220"
+                          Margin="0,0,14,0"/>
+                <TextBlock Text="{Binding SelectedBcmFileName}"
+                           Visibility="{Binding BcmFileTextVisibility}"
+                           VerticalAlignment="Center"
+                           Margin="0,0,14,0"/>
+            </StackPanel>
+        </DockPanel>
+
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="54"/>
+                <ColumnDefinition Width="6"/>
+                <ColumnDefinition Width="320" MinWidth="240" MaxWidth="420"/>
+                <ColumnDefinition Width="6"/>
+                <ColumnDefinition Width="*" MinWidth="420"/>
+            </Grid.ColumnDefinitions>
+
+            <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                <StackPanel>
+                    <StackPanel ToolTip="Add a state entry">
+                        <Button Style="{StaticResource BcmToolButton}" Command="{Binding AddRootCommand}">
+                            <iconPacks:PackIconMaterialLight Kind="Plus"/>
+                        </Button>
+                        <TextBlock Style="{StaticResource BcmToolLabel}" Text="Add"/>
+                    </StackPanel>
+                    <StackPanel ToolTip="BCM tools">
+                        <Button x:Name="ToolsButton" Style="{StaticResource BcmToolButton}" Click="ToolsButton_Click">
+                            <iconPacks:PackIconMaterial Kind="Tools" Width="15" Height="15"/>
+                            <Button.ContextMenu>
+                                <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
+                                    <MenuItem Header="Compress Loops" Command="{Binding CompressCommand}"/>
+                                    <MenuItem Header="Reindex States" Command="{Binding ReindexCommand}"/>
+                                </ContextMenu>
+                            </Button.ContextMenu>
+                        </Button>
+                        <TextBlock Style="{StaticResource BcmToolLabel}" Text="Tools"/>
+                    </StackPanel>
+                </StackPanel>
+            </ScrollViewer>
+
+            <GridSplitter Grid.Column="1" HorizontalAlignment="Stretch" Background="{DynamicResource MahApps.Brushes.Gray.SemiTransparent}"/>
+
+            <Grid Grid.Column="2">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <TextBlock Text="State Tree" FontWeight="SemiBold" FontSize="12" Margin="0,0,0,6"/>
+                <bcmViews:BcmTreeList Grid.Row="1"
+                                      x:Name="entryTree"
+                                      Entries="{Binding Entries}"
+                                      SelectedEntry="{Binding SelectedEntry, Mode=TwoWay}">
+                    <bcmViews:BcmTreeList.ContextMenu>
+                        <ContextMenu>
+                            <MenuItem Header="Add Child" Command="{Binding AddChildCommand}"/>
+                            <MenuItem Header="Add Sibling" Command="{Binding AddSiblingCommand}"/>
+                            <Separator/>
+                            <MenuItem Header="Cut" Command="{Binding CutCommand}" InputGestureText="Ctrl+X"/>
+                            <MenuItem Header="Copy" Command="{Binding CopyCommand}" InputGestureText="Ctrl+C"/>
+                            <MenuItem Header="Paste as Child" Command="{Binding PasteAsChildCommand}"/>
+                            <MenuItem Header="Paste as Sibling" Command="{Binding PasteAsSiblingCommand}" InputGestureText="Ctrl+V"/>
+                            <Separator/>
+                            <MenuItem Header="Duplicate" Command="{Binding DuplicateCommand}"/>
+                            <MenuItem Header="Delete" Command="{Binding DeleteCommand}"/>
+                            <Separator/>
+                            <MenuItem Header="Move Up" Command="{Binding MoveUpCommand}"/>
+                            <MenuItem Header="Move Down" Command="{Binding MoveDownCommand}"/>
+                        </ContextMenu>
+                    </bcmViews:BcmTreeList.ContextMenu>
+                </bcmViews:BcmTreeList>
+            </Grid>
+
+            <GridSplitter Grid.Column="3" HorizontalAlignment="Stretch" Background="{DynamicResource MahApps.Brushes.Gray.SemiTransparent}"/>
+
+            <bcmViews:BcmEntryEditor Grid.Column="4"
+                                     SelectedEntry="{Binding EditableSelectedEntry}"
+                                     IsRootEntry="{Binding IsSelectedEntryRoot}"
+                                     SiblingIndex="{Binding SelectedEntrySiblingIndex}"
+                                     ChildIndex="{Binding SelectedEntryChildIndex}"
+                                     EntryEdited="EntryEditor_EntryEdited"/>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/XenoKit/Views/BcmTab.xaml
+++ b/XenoKit/Views/BcmTab.xaml
@@ -100,12 +100,16 @@
                     <bcmViews:BcmTreeList.ContextMenu>
                         <ContextMenu>
                             <MenuItem Header="Add Child" Command="{Binding AddChildCommand}"/>
+                            <MenuItem Header="Insert Child First" Command="{Binding InsertChildCommand}"/>
                             <MenuItem Header="Add Sibling" Command="{Binding AddSiblingCommand}"/>
+                            <MenuItem Header="Insert Sibling Before" Command="{Binding InsertSiblingCommand}"/>
                             <Separator/>
                             <MenuItem Header="Cut" Command="{Binding CutCommand}" InputGestureText="Ctrl+X"/>
                             <MenuItem Header="Copy" Command="{Binding CopyCommand}" InputGestureText="Ctrl+C"/>
                             <MenuItem Header="Paste as Child" Command="{Binding PasteAsChildCommand}"/>
+                            <MenuItem Header="Paste as Child First" Command="{Binding PasteAsFirstChildCommand}"/>
                             <MenuItem Header="Paste as Sibling" Command="{Binding PasteAsSiblingCommand}" InputGestureText="Ctrl+V"/>
+                            <MenuItem Header="Paste as Sibling Before" Command="{Binding PasteBeforeSiblingCommand}"/>
                             <Separator/>
                             <MenuItem Header="Duplicate" Command="{Binding DuplicateCommand}"/>
                             <MenuItem Header="Delete" Command="{Binding DeleteCommand}"/>

--- a/XenoKit/Views/BcmTab.xaml.cs
+++ b/XenoKit/Views/BcmTab.xaml.cs
@@ -1,0 +1,679 @@
+﻿using GalaSoft.MvvmLight.CommandWpf;
+using MahApps.Metro.Controls.Dialogs;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using XenoKit.Editor;
+using XenoKit.Editor.Undo;
+using Xv2CoreLib;
+using Xv2CoreLib.BCM;
+using Xv2CoreLib.Resource.UndoRedo;
+
+namespace XenoKit.Views
+{
+    public partial class BcmTab : UserControl, INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+        public Files files => Files.Instance;
+
+        private BCM_Entry selectedEntry;
+
+        public IList<Xv2File<BCM_File>> BcmFiles
+        {
+            get
+            {
+                List<Xv2File<BCM_File>> bcmFiles = new List<Xv2File<BCM_File>>();
+                if (files.SelectedMove?.Files?.BcmFile != null) bcmFiles.Add(files.SelectedMove.Files.BcmFile);
+                if (files.SelectedMove?.Files?.AfterBcmFile != null) bcmFiles.Add(files.SelectedMove.Files.AfterBcmFile);
+                return bcmFiles;
+            }
+        }
+
+        public IList Entries => files.SelectedItem?.SelectedBcmFile?.File?.BCMEntries;
+        public Visibility BcmFileSelectorVisibility => BcmFiles.Count > 1 ? Visibility.Visible : Visibility.Collapsed;
+        public Visibility BcmFileTextVisibility => BcmFiles.Count <= 1 ? Visibility.Visible : Visibility.Collapsed;
+        public string SelectedBcmFileName => files.SelectedItem?.SelectedBcmFile?.DisplayName ?? string.Empty;
+        // Root entries anchor the state tree, so they can be selected for navigation but not edited as states.
+        public BCM_Entry EditableSelectedEntry => CanEditSelectedEntry() ? SelectedEntry : null;
+        public bool HasMultipleSelectedEntries => GetSelectedEntries().Count > 1;
+        public bool IsSelectedEntryRoot => IsRootEntry(SelectedEntry);
+        public string SelectedEntrySiblingIndex => GetNextSiblingIndex(SelectedEntry);
+        public string SelectedEntryChildIndex => GetFirstChildIndex(SelectedEntry);
+
+        public BCM_Entry SelectedEntry
+        {
+            get => selectedEntry;
+            set
+            {
+                selectedEntry = value;
+                NotifyPropertyChanged(nameof(SelectedEntry));
+                NotifyPropertyChanged(nameof(EditableSelectedEntry));
+                NotifyPropertyChanged(nameof(HasMultipleSelectedEntries));
+                NotifyPropertyChanged(nameof(IsSelectedEntryRoot));
+                NotifyPropertyChanged(nameof(SelectedEntrySiblingIndex));
+                NotifyPropertyChanged(nameof(SelectedEntryChildIndex));
+            }
+        }
+
+        public BcmTab()
+        {
+            InitializeComponent();
+            DataContext = this;
+            entryTree.ContextMenu.DataContext = this;
+            entryTree.SelectionChanged += EntryTree_SelectionChanged;
+            InputBindings.Add(new KeyBinding(CopyCommand, new KeyGesture(Key.C, ModifierKeys.Control)));
+            InputBindings.Add(new KeyBinding(PasteCommand, new KeyGesture(Key.V, ModifierKeys.Control)));
+            InputBindings.Add(new KeyBinding(CutCommand, new KeyGesture(Key.X, ModifierKeys.Control)));
+            InputBindings.Add(new KeyBinding(DeleteCommand, new KeyGesture(Key.Delete)));
+            files.PropertyChanged += Files_PropertyChanged;
+            UndoManager.Instance.UndoOrRedoCalled += UndoManager_UndoOrRedoCalled;
+            Unloaded += BcmTab_Unloaded;
+        }
+
+        private void BcmTab_Unloaded(object sender, RoutedEventArgs e)
+        {
+            UndoManager.Instance.UndoOrRedoCalled -= UndoManager_UndoOrRedoCalled;
+        }
+
+        private void UndoManager_UndoOrRedoCalled(object sender, UndoEventRaisedEventArgs e)
+        {
+            RefreshAfterUndoRedo();
+        }
+
+        private void RefreshAfterUndoRedo()
+        {
+            BCM_File file = files.SelectedItem?.SelectedBcmFile?.File;
+            BCM_Entry previousEntry = SelectedEntry;
+
+            if (file == null)
+            {
+                SelectEntry(null);
+                NotifyAll();
+                return;
+            }
+
+            RefreshTree();
+
+            if (ContainsEntry(file, previousEntry))
+                SelectEntry(previousEntry);
+            else
+                SelectEntry(GetFirstEntry(file));
+
+            entryTree?.RefreshDisplay();
+            NotifyPropertyChanged(nameof(EditableSelectedEntry));
+            NotifyPropertyChanged(nameof(HasMultipleSelectedEntries));
+            NotifyPropertyChanged(nameof(IsSelectedEntryRoot));
+            NotifyPropertyChanged(nameof(SelectedEntrySiblingIndex));
+            NotifyPropertyChanged(nameof(SelectedEntryChildIndex));
+        }
+
+        private void EntryTree_SelectionChanged(object sender, EventArgs e)
+        {
+            NotifyPropertyChanged(nameof(EditableSelectedEntry));
+            NotifyPropertyChanged(nameof(HasMultipleSelectedEntries));
+            NotifyPropertyChanged(nameof(IsSelectedEntryRoot));
+            NotifyPropertyChanged(nameof(SelectedEntrySiblingIndex));
+            NotifyPropertyChanged(nameof(SelectedEntryChildIndex));
+        }
+
+        private void Files_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(Files.SelectedItem) || e.PropertyName == nameof(Files.SelectedMove))
+            {
+                SelectedEntry = null;
+                NotifyAll();
+                RefreshTree();
+            }
+        }
+
+        private void BcmFileSelection_Changed(object sender, SelectionChangedEventArgs e)
+        {
+            SelectedEntry = null;
+            NotifyPropertyChanged(nameof(SelectedBcmFileName));
+            RefreshTree();
+        }
+
+        private void EntryEditor_EntryEdited(object sender, EventArgs e)
+        {
+            entryTree?.RefreshDisplay();
+        }
+
+        private void ToolsButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (ToolsButton.ContextMenu == null) return;
+
+            ToolsButton.ContextMenu.PlacementTarget = ToolsButton;
+            ToolsButton.ContextMenu.IsOpen = true;
+        }
+
+        public RelayCommand AddRootCommand => new RelayCommand(AddRoot);
+        private void AddRoot()
+        {
+            BCM_File file = files.SelectedItem?.SelectedBcmFile?.File;
+            if (file == null) return;
+
+            BCM_Entry entry = CreateEntry(file);
+            file.BCMEntries.Add(entry);
+            UndoManager.Instance.AddUndo(new UndoableListAdd<BCM_Entry>(file.BCMEntries, entry, "BCM Entry Add"));
+            SelectedEntry = entry;
+            RefreshTree();
+        }
+
+        public RelayCommand AddChildCommand => new RelayCommand(AddChild, () => SelectedEntry != null);
+        private void AddChild()
+        {
+            BCM_File file = files.SelectedItem?.SelectedBcmFile?.File;
+            if (file == null || SelectedEntry == null) return;
+
+            if (SelectedEntry.BCMEntries == null) SelectedEntry.BCMEntries = new List<BCM_Entry>();
+            BCM_Entry entry = CreateEntry(file);
+            SelectedEntry.BCMEntries.Add(entry);
+            UndoManager.Instance.AddUndo(new UndoableListAdd<BCM_Entry>(SelectedEntry.BCMEntries, entry, "BCM Child Add"));
+            SelectedEntry = entry;
+            RefreshTree();
+        }
+
+        public RelayCommand AddSiblingCommand => new RelayCommand(AddSibling, CanEditSelectedEntry);
+        private void AddSibling()
+        {
+            BCM_File file = files.SelectedItem?.SelectedBcmFile?.File;
+            IList<BCM_Entry> list = FindOwnerList(file?.BCMEntries, SelectedEntry);
+            if (file == null || list == null) return;
+
+            BCM_Entry entry = CreateEntry(file);
+            int index = list.IndexOf(SelectedEntry) + 1;
+            list.Insert(index, entry);
+            UndoManager.Instance.AddUndo(new UndoableListAdd<BCM_Entry>(list, entry, "BCM Sibling Add"));
+            SelectedEntry = entry;
+            RefreshTree();
+        }
+
+        public RelayCommand DuplicateCommand => new RelayCommand(DuplicateEntry, CanEditSelectedEntry);
+        private void DuplicateEntry()
+        {
+            BCM_File file = files.SelectedItem?.SelectedBcmFile?.File;
+            IList<BCM_Entry> list = FindOwnerList(file?.BCMEntries, SelectedEntry);
+            if (file == null || list == null) return;
+
+            BCM_Entry clone = SelectedEntry.Clone();
+            AssignNewIndexes(file, clone);
+            int index = list.IndexOf(SelectedEntry) + 1;
+            list.Insert(index, clone);
+            UndoManager.Instance.AddUndo(new UndoableListAdd<BCM_Entry>(list, clone, "BCM Duplicate"));
+            SelectedEntry = clone;
+            RefreshTree();
+        }
+
+        public RelayCommand CopyCommand => new RelayCommand(CopyEntry, HasSelectedEntries);
+        private void CopyEntry()
+        {
+            List<BCM_Entry> entries = GetNormalizedSelectedEntries();
+            if (entries.Count == 0) return;
+
+            DataObject data = new DataObject();
+            data.SetData(ClipboardConstants.BcmSubtrees_CopyItems, entries.Select(entry => entry.Clone()).ToList());
+            Clipboard.SetDataObject(data);
+        }
+
+        public RelayCommand CutCommand => new RelayCommand(CutEntry, HasSelectedEntries);
+        private void CutEntry()
+        {
+            CopyEntry();
+            DeleteEntry();
+        }
+
+        public RelayCommand PasteCommand => PasteAsSiblingCommand;
+        public RelayCommand PasteAsSiblingCommand => new RelayCommand(PasteAsSibling, CanPasteAsSibling);
+        public RelayCommand PasteAsChildCommand => new RelayCommand(PasteAsChild, CanPasteAsChild);
+
+        private void PasteAsSibling()
+        {
+            BCM_File file = files.SelectedItem?.SelectedBcmFile?.File;
+            List<BCM_Entry> clones = GetClipboardEntries(file);
+            if (file == null || clones.Count == 0) return;
+
+            IList<BCM_Entry> list = FindOwnerList(file.BCMEntries, SelectedEntry);
+            if (list == null) list = file.BCMEntries;
+
+            int index = SelectedEntry != null ? list.IndexOf(SelectedEntry) + 1 : list.Count;
+            List<IUndoRedo> undos = new List<IUndoRedo>();
+            foreach (BCM_Entry clone in clones)
+            {
+                list.Insert(index++, clone);
+                undos.Add(new UndoableListAdd<BCM_Entry>(list, clone, "BCM Paste"));
+            }
+
+            UndoManager.Instance.AddCompositeUndo(undos, "BCM Paste");
+            SelectedEntry = clones.LastOrDefault();
+            RefreshTree();
+        }
+
+        private void PasteAsChild()
+        {
+            BCM_File file = files.SelectedItem?.SelectedBcmFile?.File;
+            List<BCM_Entry> clones = GetClipboardEntries(file);
+            if (file == null || clones.Count == 0) return;
+
+            IList<BCM_Entry> list = SelectedEntry != null ? SelectedEntry.BCMEntries : file.BCMEntries;
+            if (SelectedEntry != null && SelectedEntry.BCMEntries == null)
+            {
+                SelectedEntry.BCMEntries = new List<BCM_Entry>();
+                list = SelectedEntry.BCMEntries;
+            }
+
+            List<IUndoRedo> undos = new List<IUndoRedo>();
+            foreach (BCM_Entry clone in clones)
+            {
+                list.Add(clone);
+                undos.Add(new UndoableListAdd<BCM_Entry>(list, clone, "BCM Paste"));
+            }
+
+            UndoManager.Instance.AddCompositeUndo(undos, "BCM Paste");
+            SelectedEntry = clones.LastOrDefault();
+            RefreshTree();
+        }
+
+        private bool CanPasteAsSibling()
+        {
+            return files.SelectedItem?.SelectedBcmFile?.File != null && Clipboard.ContainsData(ClipboardConstants.BcmSubtrees_CopyItems);
+        }
+
+        private bool CanPasteAsChild()
+        {
+            return files.SelectedItem?.SelectedBcmFile?.File != null && Clipboard.ContainsData(ClipboardConstants.BcmSubtrees_CopyItems);
+        }
+
+        private List<BCM_Entry> GetClipboardEntries(BCM_File file)
+        {
+            if (file == null || !Clipboard.ContainsData(ClipboardConstants.BcmSubtrees_CopyItems)) return new List<BCM_Entry>();
+
+            List<BCM_Entry> clones = ((List<BCM_Entry>)Clipboard.GetData(ClipboardConstants.BcmSubtrees_CopyItems))?
+                .Select(entry => entry.Clone())
+                .ToList() ?? new List<BCM_Entry>();
+
+            foreach (BCM_Entry clone in clones)
+            {
+                if (HasIndexCollision(file, clone) || clones.Where(entry => !ReferenceEquals(entry, clone)).SelectMany(entry => Flatten(new[] { entry })).Any(entry => entry.Index == clone.Index))
+                    AssignNewIndexes(file, clone);
+            }
+
+            return clones;
+        }
+
+        public RelayCommand DeleteCommand => new RelayCommand(DeleteEntry, HasSelectedEntries);
+        private async void DeleteEntry()
+        {
+            BCM_File file = files.SelectedItem?.SelectedBcmFile?.File;
+            if (file?.BCMEntries == null) return;
+
+            List<BCM_Entry> entries = GetNormalizedSelectedEntries();
+            if (entries.Count == 0) return;
+
+            if (entries.Any(entry => entry.BCMEntries?.Count > 0))
+            {
+                string message = entries.Count == 1
+                    ? "Are you sure you want to delete this entry? This will delete ALL children of this entry"
+                    : "Are you sure you want to delete these entries? This will delete ALL children of these entries";
+                MessageDialogResult result = await DialogCoordinator.Instance.ShowMessageAsync(this, "Delete BCM Entry", message, MessageDialogStyle.AffirmativeAndNegative, DialogSettings.DefaultYesNo);
+                if (result != MessageDialogResult.Affirmative)
+                    return;
+            }
+
+            List<DeleteEntryInfo> deleteInfos = entries
+                .Select(entry => new DeleteEntryInfo(entry, FindOwnerList(file.BCMEntries, entry)))
+                .Where(info => info.OwnerList != null)
+                .OrderByDescending(info => info.OwnerList.IndexOf(info.Entry))
+                .ToList();
+
+            List<IUndoRedo> undos = new List<IUndoRedo>();
+            foreach (DeleteEntryInfo info in deleteInfos)
+            {
+                int index = info.OwnerList.IndexOf(info.Entry);
+                undos.Add(new UndoableListRemove<BCM_Entry>(info.OwnerList, info.Entry, index, "BCM Delete"));
+                info.OwnerList.Remove(info.Entry);
+            }
+
+            if (undos.Count > 0)
+                UndoManager.Instance.AddCompositeUndo(undos, entries.Count > 1 ? "BCM Entries Delete" : "BCM Entry Delete");
+
+            SelectedEntry = null;
+            RefreshTree();
+        }
+
+        public RelayCommand MoveUpCommand => new RelayCommand(() => Move(-1), () => CanMove(-1));
+        public RelayCommand MoveDownCommand => new RelayCommand(() => Move(1), () => CanMove(1));
+
+        private bool CanMove(int direction)
+        {
+            IList<BCM_Entry> list = FindOwnerList(files.SelectedItem?.SelectedBcmFile?.File?.BCMEntries, SelectedEntry);
+            if (list == null || IsRootEntry(SelectedEntry)) return false;
+
+            int index = list.IndexOf(SelectedEntry);
+            int newIndex = index + direction;
+            return index >= 0 && newIndex >= 0 && newIndex < list.Count;
+        }
+
+        private void Move(int direction)
+        {
+            IList<BCM_Entry> list = FindOwnerList(files.SelectedItem?.SelectedBcmFile?.File?.BCMEntries, SelectedEntry);
+            if (list == null) return;
+
+            int oldIndex = list.IndexOf(SelectedEntry);
+            int newIndex = oldIndex + direction;
+            UndoManager.Instance.AddUndo(new ListMoveUndo<BCM_Entry>(list, oldIndex, newIndex, "BCM Move"));
+            RefreshTree();
+        }
+
+        public void SelectEntry(BCM_Entry entry)
+        {
+            SelectedEntry = entry;
+            entryTree?.SelectEntry(entry);
+        }
+
+        public void RefreshAfterFindReplace(string propertyName)
+        {
+            if (propertyName == nameof(BCM_Entry.Index))
+            {
+                RefreshTree();
+                return;
+            }
+
+            NotifyPropertyChanged(nameof(SelectedEntrySiblingIndex));
+            NotifyPropertyChanged(nameof(SelectedEntryChildIndex));
+            entryTree?.RefreshDisplay();
+        }
+
+        public RelayCommand ReindexCommand => new RelayCommand(Reindex);
+        private async void Reindex()
+        {
+            BCM_File file = files.SelectedItem?.SelectedBcmFile?.File;
+            if (file == null) return;
+
+            MessageDialogResult result = await DialogCoordinator.Instance.ShowMessageAsync(this, "Reindex BCM", "Reindex all BCM states? This changes state IDs and updates loop links.", MessageDialogStyle.AffirmativeAndNegative, DialogSettings.DefaultYesNo);
+            if (result != MessageDialogResult.Affirmative)
+                return;
+
+            List<ReindexSnapshot> oldValues = Flatten(file.BCMEntries)
+                .Select(entry => new ReindexSnapshot(entry, entry.Index, entry.LoopAsChild, entry.LoopAsSibling))
+                .ToList();
+
+            ReindexFile(file);
+
+            List<IUndoRedo> undos = new List<IUndoRedo>();
+            foreach (ReindexSnapshot oldValue in oldValues)
+            {
+                AddChangedPropertyUndo(undos, oldValue.Entry, nameof(BCM_Entry.Index), oldValue.Index, oldValue.Entry.Index);
+                AddChangedPropertyUndo(undos, oldValue.Entry, nameof(BCM_Entry.LoopAsChild), oldValue.LoopAsChild, oldValue.Entry.LoopAsChild);
+                AddChangedPropertyUndo(undos, oldValue.Entry, nameof(BCM_Entry.LoopAsSibling), oldValue.LoopAsSibling, oldValue.Entry.LoopAsSibling);
+            }
+
+            if (undos.Count > 0)
+                UndoManager.Instance.AddCompositeUndo(undos, "BCM Reindex");
+
+            RefreshTree();
+        }
+
+        public RelayCommand CompressCommand => new RelayCommand(Compress, () => false);
+        private async void Compress()
+        {
+            await DialogCoordinator.Instance.ShowMessageAsync(this, "BCM Compression", "BCM compression is not available in the current Xv2CoreLib API.", MessageDialogStyle.Affirmative, DialogSettings.Default);
+        }
+
+        private void ReindexFile(BCM_File file)
+        {
+            List<BCM_Entry> entries = Flatten(file.BCMEntries).ToList();
+            Dictionary<string, string> idMap = entries
+                .Select((entry, index) => new { OldId = entry.Index, NewId = index.ToString() })
+                .Where(item => !string.IsNullOrWhiteSpace(item.OldId))
+                .GroupBy(item => item.OldId)
+                .ToDictionary(group => group.Key, group => group.First().NewId);
+
+            for (int index = 0; index < entries.Count; index++)
+            {
+                BCM_Entry entry = entries[index];
+                entry.Index = index.ToString();
+
+                if (!string.IsNullOrWhiteSpace(entry.LoopAsChild) && idMap.TryGetValue(entry.LoopAsChild, out string childId))
+                    entry.LoopAsChild = childId;
+
+                if (!string.IsNullOrWhiteSpace(entry.LoopAsSibling) && idMap.TryGetValue(entry.LoopAsSibling, out string siblingId))
+                    entry.LoopAsSibling = siblingId;
+            }
+        }
+
+        private BCM_Entry CreateEntry(BCM_File file)
+        {
+            return new BCM_Entry
+            {
+                Index = GetNextIndex(file).ToString()
+            };
+        }
+
+        private int GetNextIndex(BCM_File file)
+        {
+            HashSet<int> used = new HashSet<int>();
+            foreach (BCM_Entry entry in Flatten(file.BCMEntries))
+            {
+                if (int.TryParse(entry.Index, out int index))
+                    used.Add(index);
+            }
+
+            int next = 0;
+            while (used.Contains(next)) next++;
+            return next;
+        }
+
+        private void AssignNewIndexes(BCM_File file, BCM_Entry entry)
+        {
+            entry.Index = GetNextIndex(file).ToString();
+            if (entry.BCMEntries == null) return;
+
+            foreach (BCM_Entry child in entry.BCMEntries)
+                AssignNewIndexes(file, child);
+        }
+
+        private bool HasIndexCollision(BCM_File file, BCM_Entry entry)
+        {
+            HashSet<string> usedIndexes = new HashSet<string>(Flatten(file.BCMEntries).Select(x => x.Index));
+            return Flatten(new[] { entry }).Any(x => usedIndexes.Contains(x.Index));
+        }
+
+        private IEnumerable<BCM_Entry> Flatten(IEnumerable<BCM_Entry> entries)
+        {
+            if (entries == null) yield break;
+
+            foreach (BCM_Entry entry in entries)
+            {
+                yield return entry;
+                foreach (BCM_Entry child in Flatten(entry.BCMEntries))
+                    yield return child;
+            }
+        }
+
+        private IList<BCM_Entry> FindOwnerList(IList<BCM_Entry> entries, BCM_Entry entry)
+        {
+            if (entries == null || entry == null) return null;
+            if (entries.Contains(entry)) return entries;
+
+            foreach (BCM_Entry child in entries)
+            {
+                IList<BCM_Entry> result = FindOwnerList(child.BCMEntries, entry);
+                if (result != null) return result;
+            }
+
+            return null;
+        }
+
+        private void RefreshTree()
+        {
+            NotifyPropertyChanged(nameof(Entries));
+            NotifyPropertyChanged(nameof(IsSelectedEntryRoot));
+            NotifyPropertyChanged(nameof(SelectedEntrySiblingIndex));
+            NotifyPropertyChanged(nameof(SelectedEntryChildIndex));
+            entryTree?.Refresh();
+        }
+
+        private bool ContainsEntry(BCM_File file, BCM_Entry entry)
+        {
+            return file != null && entry != null && Flatten(file.BCMEntries).Contains(entry);
+        }
+
+        private BCM_Entry GetFirstEntry(BCM_File file)
+        {
+            return file?.BCMEntries?.FirstOrDefault();
+        }
+
+        private void NotifyAll()
+        {
+            NotifyPropertyChanged(nameof(BcmFiles));
+            NotifyPropertyChanged(nameof(BcmFileSelectorVisibility));
+            NotifyPropertyChanged(nameof(BcmFileTextVisibility));
+            NotifyPropertyChanged(nameof(SelectedBcmFileName));
+            NotifyPropertyChanged(nameof(Entries));
+            NotifyPropertyChanged(nameof(EditableSelectedEntry));
+            NotifyPropertyChanged(nameof(HasMultipleSelectedEntries));
+            NotifyPropertyChanged(nameof(IsSelectedEntryRoot));
+            NotifyPropertyChanged(nameof(SelectedEntrySiblingIndex));
+            NotifyPropertyChanged(nameof(SelectedEntryChildIndex));
+        }
+
+        private void NotifyPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        private static void AddChangedPropertyUndo<T>(ICollection<IUndoRedo> undos, BCM_Entry entry, string propertyName, T oldValue, T newValue)
+        {
+            if (Equals(oldValue, newValue))
+                return;
+
+            undos.Add(new UndoablePropertyGeneric(propertyName, entry, oldValue, newValue, propertyName));
+        }
+
+        private bool HasSelectedEntries()
+        {
+            return GetSelectedEntries().Count > 0;
+        }
+
+        private List<BCM_Entry> GetSelectedEntries()
+        {
+            List<BCM_Entry> selectedEntries = entryTree?.SelectedEntries?.Where(entry => entry != null).ToList() ?? new List<BCM_Entry>();
+            if (selectedEntries.Count == 0 && SelectedEntry != null)
+                selectedEntries.Add(SelectedEntry);
+
+            return selectedEntries;
+        }
+
+        private List<BCM_Entry> GetNormalizedSelectedEntries()
+        {
+            List<BCM_Entry> selectedEntries = GetSelectedEntries();
+            return selectedEntries
+                .Where(entry => !selectedEntries.Any(parent => !ReferenceEquals(parent, entry) && IsDescendantOf(entry, parent)))
+                .ToList();
+        }
+
+        private bool IsDescendantOf(BCM_Entry entry, BCM_Entry possibleParent)
+        {
+            if (possibleParent?.BCMEntries == null) return false;
+
+            foreach (BCM_Entry child in possibleParent.BCMEntries)
+            {
+                if (ReferenceEquals(child, entry)) return true;
+                if (IsDescendantOf(entry, child)) return true;
+            }
+
+            return false;
+        }
+
+        private bool CanEditSelectedEntry()
+        {
+            return GetSelectedEntries().Count <= 1 && SelectedEntry != null && !IsRootEntry(SelectedEntry);
+        }
+
+        private bool IsRootEntry(BCM_Entry entry)
+        {
+            BCM_File file = files.SelectedItem?.SelectedBcmFile?.File;
+            return file?.BCMEntries != null && entry != null && file.BCMEntries.Contains(entry);
+        }
+
+        private string GetFirstChildIndex(BCM_Entry entry)
+        {
+            return entry?.BCMEntries?.FirstOrDefault()?.Index ?? "0";
+        }
+
+        private string GetNextSiblingIndex(BCM_Entry entry)
+        {
+            BCM_File file = files.SelectedItem?.SelectedBcmFile?.File;
+            IList<BCM_Entry> list = FindOwnerList(file?.BCMEntries, entry);
+            if (list == null) return "0";
+
+            int index = list.IndexOf(entry);
+            if (index < 0 || index + 1 >= list.Count) return "0";
+
+            return list[index + 1]?.Index ?? "0";
+        }
+
+        private BCM_Entry GetParentEntry(BCM_Entry entry)
+        {
+            BCM_File file = files.SelectedItem?.SelectedBcmFile?.File;
+            if (file?.BCMEntries == null || entry == null) return null;
+
+            foreach (BCM_Entry rootEntry in file.BCMEntries)
+            {
+                BCM_Entry parent = FindParent(rootEntry, entry);
+                if (parent != null) return parent;
+            }
+
+            return null;
+        }
+
+        private BCM_Entry FindParent(BCM_Entry parent, BCM_Entry entry)
+        {
+            if (parent?.BCMEntries == null) return null;
+
+            foreach (BCM_Entry child in parent.BCMEntries)
+            {
+                if (ReferenceEquals(child, entry)) return parent;
+
+                BCM_Entry result = FindParent(child, entry);
+                if (result != null) return result;
+            }
+
+            return null;
+        }
+
+        private class ReindexSnapshot
+        {
+            public BCM_Entry Entry { get; }
+            public string Index { get; }
+            public string LoopAsChild { get; }
+            public string LoopAsSibling { get; }
+
+            public ReindexSnapshot(BCM_Entry entry, string index, string loopAsChild, string loopAsSibling)
+            {
+                Entry = entry;
+                Index = index;
+                LoopAsChild = loopAsChild;
+                LoopAsSibling = loopAsSibling;
+            }
+        }
+
+        private class DeleteEntryInfo
+        {
+            public BCM_Entry Entry { get; }
+            public IList<BCM_Entry> OwnerList { get; }
+
+            public DeleteEntryInfo(BCM_Entry entry, IList<BCM_Entry> ownerList)
+            {
+                Entry = entry;
+                OwnerList = ownerList;
+            }
+        }
+
+    }
+}

--- a/XenoKit/Views/BcmTab.xaml.cs
+++ b/XenoKit/Views/BcmTab.xaml.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
@@ -22,6 +23,7 @@ namespace XenoKit.Views
         public Files files => Files.Instance;
 
         private BCM_Entry selectedEntry;
+        private bool isUndoRedoHooked;
 
         public IList<Xv2File<BCM_File>> BcmFiles
         {
@@ -71,13 +73,27 @@ namespace XenoKit.Views
             InputBindings.Add(new KeyBinding(CutCommand, new KeyGesture(Key.X, ModifierKeys.Control)));
             InputBindings.Add(new KeyBinding(DeleteCommand, new KeyGesture(Key.Delete)));
             files.PropertyChanged += Files_PropertyChanged;
-            UndoManager.Instance.UndoOrRedoCalled += UndoManager_UndoOrRedoCalled;
+            Loaded += BcmTab_Loaded;
             Unloaded += BcmTab_Unloaded;
+        }
+
+        private void BcmTab_Loaded(object sender, RoutedEventArgs e)
+        {
+            if (!isUndoRedoHooked)
+            {
+                UndoManager.Instance.UndoOrRedoCalled += UndoManager_UndoOrRedoCalled;
+                isUndoRedoHooked = true;
+            }
+
+            RefreshAfterUndoRedo();
         }
 
         private void BcmTab_Unloaded(object sender, RoutedEventArgs e)
         {
+            if (!isUndoRedoHooked) return;
+
             UndoManager.Instance.UndoOrRedoCalled -= UndoManager_UndoOrRedoCalled;
+            isUndoRedoHooked = false;
         }
 
         private void UndoManager_UndoOrRedoCalled(object sender, UndoEventRaisedEventArgs e)
@@ -158,10 +174,7 @@ namespace XenoKit.Views
             if (file == null) return;
 
             BCM_Entry entry = CreateEntry(file);
-            file.BCMEntries.Add(entry);
-            UndoManager.Instance.AddUndo(new UndoableListAdd<BCM_Entry>(file.BCMEntries, entry, "BCM Entry Add"));
-            SelectedEntry = entry;
-            RefreshTree();
+            AddEntryToList(file, file.BCMEntries, entry, file.BCMEntries.Count, "BCM Entry Add");
         }
 
         public RelayCommand AddChildCommand => new RelayCommand(AddChild, () => SelectedEntry != null);
@@ -172,10 +185,18 @@ namespace XenoKit.Views
 
             if (SelectedEntry.BCMEntries == null) SelectedEntry.BCMEntries = new List<BCM_Entry>();
             BCM_Entry entry = CreateEntry(file);
-            SelectedEntry.BCMEntries.Add(entry);
-            UndoManager.Instance.AddUndo(new UndoableListAdd<BCM_Entry>(SelectedEntry.BCMEntries, entry, "BCM Child Add"));
-            SelectedEntry = entry;
-            RefreshTree();
+            AddEntryToList(file, SelectedEntry.BCMEntries, entry, SelectedEntry.BCMEntries.Count, "BCM Child Add");
+        }
+
+        public RelayCommand InsertChildCommand => new RelayCommand(InsertChild, () => SelectedEntry != null);
+        private void InsertChild()
+        {
+            BCM_File file = files.SelectedItem?.SelectedBcmFile?.File;
+            if (file == null || SelectedEntry == null) return;
+
+            if (SelectedEntry.BCMEntries == null) SelectedEntry.BCMEntries = new List<BCM_Entry>();
+            BCM_Entry entry = CreateEntry(file);
+            AddEntryToList(file, SelectedEntry.BCMEntries, entry, 0, "BCM Child Insert");
         }
 
         public RelayCommand AddSiblingCommand => new RelayCommand(AddSibling, CanEditSelectedEntry);
@@ -187,10 +208,19 @@ namespace XenoKit.Views
 
             BCM_Entry entry = CreateEntry(file);
             int index = list.IndexOf(SelectedEntry) + 1;
-            list.Insert(index, entry);
-            UndoManager.Instance.AddUndo(new UndoableListAdd<BCM_Entry>(list, entry, "BCM Sibling Add"));
-            SelectedEntry = entry;
-            RefreshTree();
+            AddEntryToList(file, list, entry, index, "BCM Sibling Add");
+        }
+
+        public RelayCommand InsertSiblingCommand => new RelayCommand(InsertSibling, CanEditSelectedEntry);
+        private void InsertSibling()
+        {
+            BCM_File file = files.SelectedItem?.SelectedBcmFile?.File;
+            IList<BCM_Entry> list = FindOwnerList(file?.BCMEntries, SelectedEntry);
+            if (file == null || list == null) return;
+
+            BCM_Entry entry = CreateEntry(file);
+            int index = list.IndexOf(SelectedEntry);
+            AddEntryToList(file, list, entry, index, "BCM Sibling Insert");
         }
 
         public RelayCommand DuplicateCommand => new RelayCommand(DuplicateEntry, CanEditSelectedEntry);
@@ -200,13 +230,9 @@ namespace XenoKit.Views
             IList<BCM_Entry> list = FindOwnerList(file?.BCMEntries, SelectedEntry);
             if (file == null || list == null) return;
 
-            BCM_Entry clone = SelectedEntry.Clone();
-            AssignNewIndexes(file, clone);
+            BCM_Entry clone = CloneEntryTree(SelectedEntry);
             int index = list.IndexOf(SelectedEntry) + 1;
-            list.Insert(index, clone);
-            UndoManager.Instance.AddUndo(new UndoableListAdd<BCM_Entry>(list, clone, "BCM Duplicate"));
-            SelectedEntry = clone;
-            RefreshTree();
+            AddEntryToList(file, list, clone, index, "BCM Duplicate");
         }
 
         public RelayCommand CopyCommand => new RelayCommand(CopyEntry, HasSelectedEntries);
@@ -216,7 +242,7 @@ namespace XenoKit.Views
             if (entries.Count == 0) return;
 
             DataObject data = new DataObject();
-            data.SetData(ClipboardConstants.BcmSubtrees_CopyItems, entries.Select(entry => entry.Clone()).ToList());
+            data.SetData(ClipboardConstants.BcmSubtrees_CopyItems, entries.Select(CloneEntryTree).ToList());
             Clipboard.SetDataObject(data);
         }
 
@@ -230,6 +256,8 @@ namespace XenoKit.Views
         public RelayCommand PasteCommand => PasteAsSiblingCommand;
         public RelayCommand PasteAsSiblingCommand => new RelayCommand(PasteAsSibling, CanPasteAsSibling);
         public RelayCommand PasteAsChildCommand => new RelayCommand(PasteAsChild, CanPasteAsChild);
+        public RelayCommand PasteBeforeSiblingCommand => new RelayCommand(PasteBeforeSibling, CanPasteBeforeSibling);
+        public RelayCommand PasteAsFirstChildCommand => new RelayCommand(PasteAsFirstChild, CanPasteAsFirstChild);
 
         private void PasteAsSibling()
         {
@@ -241,16 +269,7 @@ namespace XenoKit.Views
             if (list == null) list = file.BCMEntries;
 
             int index = SelectedEntry != null ? list.IndexOf(SelectedEntry) + 1 : list.Count;
-            List<IUndoRedo> undos = new List<IUndoRedo>();
-            foreach (BCM_Entry clone in clones)
-            {
-                list.Insert(index++, clone);
-                undos.Add(new UndoableListAdd<BCM_Entry>(list, clone, "BCM Paste"));
-            }
-
-            UndoManager.Instance.AddCompositeUndo(undos, "BCM Paste");
-            SelectedEntry = clones.LastOrDefault();
-            RefreshTree();
+            PasteEntriesToList(file, list, clones, index, "BCM Paste");
         }
 
         private void PasteAsChild()
@@ -266,16 +285,34 @@ namespace XenoKit.Views
                 list = SelectedEntry.BCMEntries;
             }
 
-            List<IUndoRedo> undos = new List<IUndoRedo>();
-            foreach (BCM_Entry clone in clones)
+            PasteEntriesToList(file, list, clones, list.Count, "BCM Paste");
+        }
+
+        private void PasteBeforeSibling()
+        {
+            BCM_File file = files.SelectedItem?.SelectedBcmFile?.File;
+            List<BCM_Entry> clones = GetClipboardEntries(file);
+            IList<BCM_Entry> list = FindOwnerList(file?.BCMEntries, SelectedEntry);
+            if (file == null || clones.Count == 0 || list == null) return;
+
+            int index = list.IndexOf(SelectedEntry);
+            PasteEntriesToList(file, list, clones, index, "BCM Paste");
+        }
+
+        private void PasteAsFirstChild()
+        {
+            BCM_File file = files.SelectedItem?.SelectedBcmFile?.File;
+            List<BCM_Entry> clones = GetClipboardEntries(file);
+            if (file == null || clones.Count == 0) return;
+
+            IList<BCM_Entry> list = SelectedEntry != null ? SelectedEntry.BCMEntries : file.BCMEntries;
+            if (SelectedEntry != null && SelectedEntry.BCMEntries == null)
             {
-                list.Add(clone);
-                undos.Add(new UndoableListAdd<BCM_Entry>(list, clone, "BCM Paste"));
+                SelectedEntry.BCMEntries = new List<BCM_Entry>();
+                list = SelectedEntry.BCMEntries;
             }
 
-            UndoManager.Instance.AddCompositeUndo(undos, "BCM Paste");
-            SelectedEntry = clones.LastOrDefault();
-            RefreshTree();
+            PasteEntriesToList(file, list, clones, 0, "BCM Paste");
         }
 
         private bool CanPasteAsSibling()
@@ -288,21 +325,49 @@ namespace XenoKit.Views
             return files.SelectedItem?.SelectedBcmFile?.File != null && Clipboard.ContainsData(ClipboardConstants.BcmSubtrees_CopyItems);
         }
 
+        private bool CanPasteBeforeSibling()
+        {
+            return CanEditSelectedEntry() && Clipboard.ContainsData(ClipboardConstants.BcmSubtrees_CopyItems);
+        }
+
+        private bool CanPasteAsFirstChild()
+        {
+            return files.SelectedItem?.SelectedBcmFile?.File != null && Clipboard.ContainsData(ClipboardConstants.BcmSubtrees_CopyItems);
+        }
+
         private List<BCM_Entry> GetClipboardEntries(BCM_File file)
         {
             if (file == null || !Clipboard.ContainsData(ClipboardConstants.BcmSubtrees_CopyItems)) return new List<BCM_Entry>();
 
             List<BCM_Entry> clones = ((List<BCM_Entry>)Clipboard.GetData(ClipboardConstants.BcmSubtrees_CopyItems))?
-                .Select(entry => entry.Clone())
+                .Select(CloneEntryTree)
                 .ToList() ?? new List<BCM_Entry>();
 
-            foreach (BCM_Entry clone in clones)
-            {
-                if (HasIndexCollision(file, clone) || clones.Where(entry => !ReferenceEquals(entry, clone)).SelectMany(entry => Flatten(new[] { entry })).Any(entry => entry.Index == clone.Index))
-                    AssignNewIndexes(file, clone);
-            }
-
             return clones;
+        }
+
+        private BCM_Entry CloneEntryTree(BCM_Entry entry)
+        {
+            if (entry == null) return null;
+
+            BCM_Entry clone = entry.Clone();
+            clone.InsertAt = entry.InsertAt;
+            clone.LoopAsChild = entry.LoopAsChild;
+            clone.LoopAsSibling = entry.LoopAsSibling;
+            clone.BCMEntries = entry.BCMEntries?
+                .Select(CloneEntryTree)
+                .Where(child => child != null)
+                .ToList() ?? new List<BCM_Entry>();
+
+            return clone;
+        }
+
+        private List<BCM_Entry> CloneEntryTreeList(IEnumerable<BCM_Entry> entries)
+        {
+            return entries?
+                .Select(CloneEntryTree)
+                .Where(entry => entry != null)
+                .ToList() ?? new List<BCM_Entry>();
         }
 
         public RelayCommand DeleteCommand => new RelayCommand(DeleteEntry, HasSelectedEntries);
@@ -330,6 +395,7 @@ namespace XenoKit.Views
                 .OrderByDescending(info => info.OwnerList.IndexOf(info.Entry))
                 .ToList();
 
+            List<ReindexSnapshot> oldValues = GetReindexSnapshots(file);
             List<IUndoRedo> undos = new List<IUndoRedo>();
             foreach (DeleteEntryInfo info in deleteInfos)
             {
@@ -339,7 +405,7 @@ namespace XenoKit.Views
             }
 
             if (undos.Count > 0)
-                UndoManager.Instance.AddCompositeUndo(undos, entries.Count > 1 ? "BCM Entries Delete" : "BCM Entry Delete");
+                AddCompositeUndoWithReindex(file, undos, oldValues, entries.Count > 1 ? "BCM Entries Delete" : "BCM Entry Delete");
 
             SelectedEntry = null;
             RefreshTree();
@@ -398,10 +464,63 @@ namespace XenoKit.Views
             if (result != MessageDialogResult.Affirmative)
                 return;
 
-            List<ReindexSnapshot> oldValues = Flatten(file.BCMEntries)
+            List<ReindexSnapshot> oldValues = GetReindexSnapshots(file);
+            List<IUndoRedo> undos = ReindexWithUndo(file, oldValues);
+
+            if (undos.Count > 0)
+                UndoManager.Instance.AddCompositeUndo(undos, "BCM Reindex");
+
+            RefreshTree();
+        }
+
+        public RelayCommand CompressCommand => new RelayCommand(Compress, IsBcmFileLoaded);
+        private async void Compress()
+        {
+            BCM_File file = files.SelectedItem?.SelectedBcmFile?.File;
+            if (file == null) return;
+
+            List<BCM_Entry> oldEntries = CloneEntryTreeList(file.BCMEntries);
+            int removedCount;
+
+            try
+            {
+                removedCount = file.CompressLoops();
+            }
+            catch (InvalidDataException ex)
+            {
+                await DialogCoordinator.Instance.ShowMessageAsync(this, "BCM Compression", ex.Message, MessageDialogStyle.Affirmative, DialogSettings.Default);
+                return;
+            }
+
+            if (removedCount == 0)
+            {
+                await DialogCoordinator.Instance.ShowMessageAsync(this, "BCM Compression", "No repeated BCM child loops were found.", MessageDialogStyle.Affirmative, DialogSettings.Default);
+                return;
+            }
+
+            List<BCM_Entry> newEntries = CloneEntryTreeList(file.BCMEntries);
+            UndoManager.Instance.AddUndo(new UndoablePropertyGeneric(nameof(BCM_File.BCMEntries), file, oldEntries, newEntries, "BCM Compress Loops"));
+
+            SelectedEntry = null;
+            RefreshTree();
+
+            await DialogCoordinator.Instance.ShowMessageAsync(this, "BCM Compression", $"Compressed BCM loops. Removed {removedCount} repeated entries.", MessageDialogStyle.Affirmative, DialogSettings.Default);
+        }
+
+        private bool IsBcmFileLoaded()
+        {
+            return files.SelectedItem?.SelectedBcmFile?.File != null;
+        }
+
+        private List<ReindexSnapshot> GetReindexSnapshots(BCM_File file)
+        {
+            return Flatten(file?.BCMEntries)
                 .Select(entry => new ReindexSnapshot(entry, entry.Index, entry.LoopAsChild, entry.LoopAsSibling))
                 .ToList();
+        }
 
+        private List<IUndoRedo> ReindexWithUndo(BCM_File file, List<ReindexSnapshot> oldValues)
+        {
             ReindexFile(file);
 
             List<IUndoRedo> undos = new List<IUndoRedo>();
@@ -412,16 +531,60 @@ namespace XenoKit.Views
                 AddChangedPropertyUndo(undos, oldValue.Entry, nameof(BCM_Entry.LoopAsSibling), oldValue.LoopAsSibling, oldValue.Entry.LoopAsSibling);
             }
 
-            if (undos.Count > 0)
-                UndoManager.Instance.AddCompositeUndo(undos, "BCM Reindex");
+            return undos;
+        }
 
+        private void AddCompositeUndoWithReindex(BCM_File file, List<IUndoRedo> structuralUndos, List<ReindexSnapshot> oldValues, string message)
+        {
+            List<IUndoRedo> undos = structuralUndos ?? new List<IUndoRedo>();
+            undos.AddRange(ReindexWithUndo(file, oldValues));
+
+            if (undos.Count > 0)
+                UndoManager.Instance.AddCompositeUndo(undos, message);
+        }
+
+        private void AddEntryToList(BCM_File file, IList<BCM_Entry> list, BCM_Entry entry, int index, string message)
+        {
+            if (file == null || list == null || entry == null) return;
+
+            List<ReindexSnapshot> oldValues = GetReindexSnapshots(file);
+            int insertIndex = ClampListIndex(list, index);
+            list.Insert(insertIndex, entry);
+
+            List<IUndoRedo> undos = new List<IUndoRedo>
+            {
+                new UndoableListAdd<BCM_Entry>(list, entry, message)
+            };
+
+            AddCompositeUndoWithReindex(file, undos, oldValues, message);
+            SelectedEntry = entry;
             RefreshTree();
         }
 
-        public RelayCommand CompressCommand => new RelayCommand(Compress, () => false);
-        private async void Compress()
+        private void PasteEntriesToList(BCM_File file, IList<BCM_Entry> list, List<BCM_Entry> clones, int index, string message)
         {
-            await DialogCoordinator.Instance.ShowMessageAsync(this, "BCM Compression", "BCM compression is not available in the current Xv2CoreLib API.", MessageDialogStyle.Affirmative, DialogSettings.Default);
+            if (file == null || list == null || clones == null || clones.Count == 0) return;
+
+            List<ReindexSnapshot> oldValues = GetReindexSnapshots(file);
+            int insertIndex = ClampListIndex(list, index);
+            List<IUndoRedo> undos = new List<IUndoRedo>();
+
+            foreach (BCM_Entry clone in clones)
+            {
+                list.Insert(insertIndex++, clone);
+                undos.Add(new UndoableListAdd<BCM_Entry>(list, clone, message));
+            }
+
+            AddCompositeUndoWithReindex(file, undos, oldValues, message);
+            SelectedEntry = clones.LastOrDefault();
+            RefreshTree();
+        }
+
+        private int ClampListIndex(IList<BCM_Entry> list, int index)
+        {
+            if (index < 0) return 0;
+            if (index > list.Count) return list.Count;
+            return index;
         }
 
         private void ReindexFile(BCM_File file)
@@ -466,21 +629,6 @@ namespace XenoKit.Views
             int next = 0;
             while (used.Contains(next)) next++;
             return next;
-        }
-
-        private void AssignNewIndexes(BCM_File file, BCM_Entry entry)
-        {
-            entry.Index = GetNextIndex(file).ToString();
-            if (entry.BCMEntries == null) return;
-
-            foreach (BCM_Entry child in entry.BCMEntries)
-                AssignNewIndexes(file, child);
-        }
-
-        private bool HasIndexCollision(BCM_File file, BCM_Entry entry)
-        {
-            HashSet<string> usedIndexes = new HashSet<string>(Flatten(file.BCMEntries).Select(x => x.Index));
-            return Flatten(new[] { entry }).Any(x => usedIndexes.Contains(x.Index));
         }
 
         private IEnumerable<BCM_Entry> Flatten(IEnumerable<BCM_Entry> entries)

--- a/XenoKit/Windows/FindAndReplace.Bcm.cs
+++ b/XenoKit/Windows/FindAndReplace.Bcm.cs
@@ -1,0 +1,144 @@
+﻿using MahApps.Metro.Controls;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Windows;
+using XenoKit.Helper.Find;
+using Xv2CoreLib.BAC;
+using LB_Common;
+using static Xv2CoreLib.Xenoverse2;
+using XenoKit.Editor;
+using Xv2CoreLib.Resource.UndoRedo;
+using GalaSoft.MvvmLight.CommandWpf;
+using Xv2CoreLib.BCM;
+
+namespace XenoKit.Windows
+{
+    public partial class FindAndReplace
+    {
+        private BCM_Entry FindBcmValue(BCM_File file, string valueName, object value, BCM_Entry previousEntry, bool isNot)
+        {
+            List<BCM_Entry> entries = FlattenBcmEntries(file.BCMEntries).ToList();
+            if (entries.Count == 0) return null;
+
+            int startIndex = 0;
+            BCM_Entry selectedEntry = mainWindow.bcmTabView.SelectedEntry;
+            int previousIndex = previousEntry != null ? entries.IndexOf(previousEntry) : entries.IndexOf(selectedEntry);
+            if (previousIndex >= 0)
+                startIndex = previousIndex + 1;
+
+            for (int offset = 0; offset < entries.Count; offset++)
+            {
+                BCM_Entry entry = entries[(startIndex + offset) % entries.Count];
+                object entryValue = entry.GetType().GetProperty(valueName)?.GetValue(entry);
+                bool matches = ValuesEqual(entryValue, value, SelectedValue.valueType);
+                if (isNot) matches = !matches;
+                if (matches) return entry;
+            }
+
+            return null;
+        }
+
+        private List<IUndoRedo> ReplaceBcmValue(BCM_File file, string valueName, object valueToFind, object valueToReplace, out int numReplaced)
+        {
+            List<IUndoRedo> undos = new List<IUndoRedo>();
+            numReplaced = 0;
+
+            foreach (BCM_Entry entry in FlattenBcmEntries(file.BCMEntries))
+            {
+                if (IsRootBcmEntry(file, entry)) continue;
+
+                var property = entry.GetType().GetProperty(valueName);
+                if (property == null) continue;
+
+                object oldValue = property.GetValue(entry);
+                if (!ValuesEqual(oldValue, valueToFind, SelectedValue.valueType)) continue;
+                if (ValuesEqual(oldValue, valueToReplace, SelectedValue.valueType)) continue;
+
+                undos.Add(new UndoablePropertyGeneric(valueName, entry, oldValue, valueToReplace, SelectedValue.ValueName));
+                property.SetValue(entry, valueToReplace);
+                numReplaced++;
+            }
+
+            return undos;
+        }
+
+        private IEnumerable<BCM_Entry> FlattenBcmEntries(IEnumerable<BCM_Entry> entries)
+        {
+            if (entries == null) yield break;
+
+            foreach (BCM_Entry entry in entries)
+            {
+                yield return entry;
+
+                foreach (BCM_Entry child in FlattenBcmEntries(entry.BCMEntries))
+                    yield return child;
+            }
+        }
+
+        private bool IsRootBcmEntry(BCM_File file, BCM_Entry entry)
+        {
+            return file?.BCMEntries != null && entry != null && file.BCMEntries.Contains(entry);
+        }
+
+        private static bool ValuesEqual(object first, object second, Type type)
+        {
+            if (first == null || second == null) return Equals(first, second);
+
+            if (type == typeof(float))
+                return Math.Abs((float)first - (float)second) < 0.000001f;
+
+            if (type == typeof(double))
+                return Math.Abs((double)first - (double)second) < 0.000001d;
+
+            return Equals(first, second);
+        }
+
+        private static List<Value> CreateBcmValues()
+        {
+            return new List<Value>
+            {
+                BcmValue("State Id", nameof(BCM_Entry.Index)),
+                BcmValue("Directional Input", nameof(BCM_Entry.DirectionalInput)),
+                BcmValue("Button Input", nameof(BCM_Entry.ButtonInput)),
+                BcmValue("Hold Down Conditions", nameof(BCM_Entry.HoldDownConditions)),
+                BcmValue("Opponent Size", nameof(BCM_Entry.OpponentSizeConditions)),
+                BcmValue("Minimum Loop Duration", nameof(BCM_Entry.MinimumLoopDuration)),
+                BcmValue("Maximum Loop Duration", nameof(BCM_Entry.MaximumLoopDuration)),
+                BcmValue("Primary Conditions", nameof(BCM_Entry.PrimaryActivatorConditions)),
+                BcmValue("Activator State", nameof(BCM_Entry.ActivatorState)),
+                BcmValue("Primary BAC", nameof(BCM_Entry.BacEntryPrimary)),
+                BcmValue("Airborne BAC", nameof(BCM_Entry.BacEntryAirborne)),
+                BcmValue("Charge BAC", nameof(BCM_Entry.BacEntryCharge)),
+                BcmValue("User Connect BAC", nameof(BCM_Entry.BacEntryUserConnect)),
+                BcmValue("Victim Connect BAC", nameof(BCM_Entry.BacEntryVictimConnect)),
+                BcmValue("Targeting Override BAC", nameof(BCM_Entry.BacEntryTargetingOverride)),
+                BcmValue("Mode", nameof(BCM_Entry.RandomFlag)),
+                BcmValue("Ki Cost", nameof(BCM_Entry.I_64)),
+                BcmValue("Receiver Link Id", nameof(BCM_Entry.ReceiverLinkID)),
+                BcmValue("Stamina Cost", nameof(BCM_Entry.StaminaCost)),
+                BcmValue("Ki Required", nameof(BCM_Entry.KiRequired)),
+                BcmValue("Health Required", nameof(BCM_Entry.HealthRequired)),
+                BcmValue("Transformation Stage", nameof(BCM_Entry.TransStage)),
+                BcmValue("CUS Aura", nameof(BCM_Entry.CusAura)),
+                BcmValue("I_00", nameof(BCM_Entry.I_00)),
+                BcmValue("I_36", nameof(BCM_Entry.I_36)),
+                BcmValue("I_68", nameof(BCM_Entry.I_68)),
+                BcmValue("I_72", nameof(BCM_Entry.I_72)),
+                BcmValue("I_80", nameof(BCM_Entry.I_80)),
+                BcmValue("I_88", nameof(BCM_Entry.I_88)),
+                BcmValue("I_104", nameof(BCM_Entry.I_104)),
+                BcmValue("I_108", nameof(BCM_Entry.I_108))
+            };
+        }
+
+        private static Value BcmValue(string displayName, string propertyName)
+        {
+            return new Value(typeof(BCM_Entry).GetProperty(propertyName).PropertyType, propertyName, null, null, displayName);
+        }
+
+    }
+}

--- a/XenoKit/Windows/FindAndReplace.xaml
+++ b/XenoKit/Windows/FindAndReplace.xaml
@@ -25,7 +25,7 @@
                 </Grid>
                 <CheckBox Content="Replace" IsChecked="{Binding ReplaceMode}" Margin="10,0" VerticalAlignment="Center"/>
             </StackPanel>
-            <Grid Margin="3,5,0,0" Width="250" HorizontalAlignment="Left">
+            <Grid x:Name="bacTypeGrid" Margin="3,5,0,0" Width="250" HorizontalAlignment="Left" Visibility="{Binding BacTypeVisibility}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="100"/>
                     <ColumnDefinition Width="*"/>

--- a/XenoKit/Windows/FindAndReplace.xaml.cs
+++ b/XenoKit/Windows/FindAndReplace.xaml.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Windows;
@@ -12,6 +13,7 @@ using static Xv2CoreLib.Xenoverse2;
 using XenoKit.Editor;
 using Xv2CoreLib.Resource.UndoRedo;
 using GalaSoft.MvvmLight.CommandWpf;
+using Xv2CoreLib.BCM;
 
 namespace XenoKit.Windows
 {
@@ -34,7 +36,8 @@ namespace XenoKit.Windows
         
         public Dictionary<MoveFileTypes, string> FileTypes { get; private set; } = new Dictionary<MoveFileTypes, string>()
         {
-            { MoveFileTypes.BAC , "BAC" }
+            { MoveFileTypes.BAC , "BAC" },
+            { MoveFileTypes.BCM , "BCM" }
         };
 
         public Dictionary<Type, string> BacTypes { get; private set; } = new Dictionary<Type, string>()
@@ -98,7 +101,11 @@ namespace XenoKit.Windows
                     _selectedFileType = value;
                     NotifyPropertyChanged(nameof(SelectedFileType));
                     NotifyPropertyChanged(nameof(Values));
+                    NotifyPropertyChanged(nameof(BacTypeVisibility));
                     ResetState();
+
+                    if (Values.Count > 0)
+                        SelectedValue = Values[0];
                 }
             }
         }
@@ -135,7 +142,12 @@ namespace XenoKit.Windows
         {
             get
             {
-                //add different logic here when other file types are added
+                if (SelectedFileType == MoveFileTypes.BCM)
+                {
+                    _values = CreateBcmValues();
+                    return _values;
+                }
+
                 _values = Find.ParseAllProps(SelectedBacType);
 
                 //Remove all not-supported enums
@@ -172,6 +184,7 @@ namespace XenoKit.Windows
             }
         }
         public string ValueToolTip => CreateValueToolTipForEnum();
+        public Visibility BacTypeVisibility => SelectedFileType == MoveFileTypes.BAC ? Visibility.Visible : Visibility.Collapsed;
 
         public bool ReplaceMode
         {
@@ -261,6 +274,50 @@ namespace XenoKit.Windows
                     }
                 }
             }
+            else if (SelectedFileType == MoveFileTypes.BCM)
+            {
+                BCM_File file = Files.Instance.SelectedItem?.SelectedBcmFile?.File;
+                if (file == null)
+                {
+                    LogLocalMessage("No BCM file is selected.");
+                    return;
+                }
+
+                if (ReplaceMode)
+                {
+                    object valueToFind = null;
+                    object valueToReplace = null;
+
+                    ConvertToType(ValueToFind, SelectedValue.valueType, ref valueToFind);
+                    ConvertToType(ValueToReplace, SelectedValue.valueType, ref valueToReplace);
+
+                    List<IUndoRedo> undos = ReplaceBcmValue(file, SelectedValue.valueName, valueToFind, valueToReplace, out int numReplaced);
+                    if (undos.Count > 0)
+                        UndoManager.Instance.AddCompositeUndo(undos, "BCM Replace All");
+
+                    mainWindow.bcmTabView.RefreshAfterFindReplace(SelectedValue.valueName);
+                    LogLocalMessage($"Replaced {numReplaced} values.");
+                }
+                else
+                {
+                    object valueToFind = null;
+                    ConvertToType(ValueToFind, SelectedValue.valueType, ref valueToFind);
+
+                    BCM_Entry entry = FindBcmValue(file, SelectedValue.valueName, valueToFind, prevFoundItem as BCM_Entry, NotMode);
+                    prevFoundItem = entry;
+
+                    if (entry != null)
+                    {
+                        mainWindow.mainTabControl.SelectedItem = mainWindow.stateTab;
+                        mainWindow.bcmTabView.SelectEntry(entry);
+                        LogLocalMessage("Found a matching value.");
+                    }
+                    else
+                    {
+                        LogLocalMessage("Nothing found.");
+                    }
+                }
+            }
             else
             {
                 LogLocalMessage("Undefined file type!");
@@ -270,6 +327,13 @@ namespace XenoKit.Windows
             UpdateUIElements();
             UndoManager.Instance.ForceEventCall();
         }
+
+
+
+
+
+
+
 
         public RelayCommand ExitCommand => new RelayCommand(Exit);
         private void Exit()
@@ -298,74 +362,44 @@ namespace XenoKit.Windows
         {
             if (type == null) return false;
 
-            if (type.IsInt8())
+            value = value?.Trim() ?? string.Empty;
+
+            if (type.IsString())
             {
-                byte ret;
-                if (!byte.TryParse(value, out ret))
+                result = value;
+                return true;
+            }
+
+            if (type.IsBool())
+            {
+                if (value.ToLower() != "true" && value.ToLower() != "false")
                     return false;
 
-                result = ret;
+                result = value.ToLower() == "true";
+                return true;
             }
-            else if (type.IsUInt8())
-            {
-                sbyte ret;
-                if (!sbyte.TryParse(value, out ret))
-                    return false;
 
-                result = ret;
-            }
-            else if (type.IsInt16())
+            if (type.IsEnum())
             {
-                short ret;
-                if (!short.TryParse(value, out ret))
-                    return false;
+                try
+                {
+                    result = Enum.Parse(type, value, true);
+                    return true;
+                }
+                catch
+                {
+                    if (!TryParseInteger(value, out long enumNumber))
+                        return false;
 
-                result = ret;
+                    result = Enum.ToObject(type, enumNumber);
+                    return true;
+                }
             }
-            else if (type.IsUInt16())
-            {
-                ushort ret;
-                if (!ushort.TryParse(value, out ret))
-                    return false;
 
-                result = ret;
-            }
-            else if (type.IsInt32())
-            {
-                int ret;
-                if (!int.TryParse(value, out ret))
-                    return false;
-
-                result = ret;
-            }
-            else if (type.IsUInt32())
-            {
-                uint ret;
-                if (!uint.TryParse(value, out ret))
-                    return false;
-
-                result = ret;
-            }
-            else if (type.IsInt64())
-            {
-                long ret;
-                if (!long.TryParse(value, out ret))
-                    return false;
-
-                result = ret;
-            }
-            else if (type.IsInt64())
-            {
-                ulong ret;
-                if (!ulong.TryParse(value, out ret))
-                    return false;
-
-                result = ret;
-            }
-            else if (type.IsFloat())
+            if (type.IsFloat())
             {
                 float ret;
-                if (!float.TryParse(value, out ret))
+                if (!float.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out ret))
                     return false;
 
                 result = ret;
@@ -373,82 +407,81 @@ namespace XenoKit.Windows
             else if (type.IsDouble())
             {
                 double ret;
-                if (!double.TryParse(value, out ret))
+                if (!double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out ret))
                     return false;
 
                 result = ret;
             }
-            else if (type.IsBool())
+            else if (type.IsInt8())
             {
-                if (value.ToLower() != "true" && value.ToLower() != "false")
+                if (!TryParseInteger(value, out long number) || number < byte.MinValue || number > byte.MaxValue)
                     return false;
 
-                result = (value.ToLower() == "true") ? true : false;
+                result = (byte)number;
             }
-            else if (type.IsString())
+            else if (type.IsUInt8())
             {
-                result = value;
+                if (!TryParseInteger(value, out long number) || number < sbyte.MinValue || number > sbyte.MaxValue)
+                    return false;
+
+                result = (sbyte)number;
             }
-            else if (type.IsEnum())
+            else if (type.IsInt16())
             {
-                object ret = null;
+                if (!TryParseInteger(value, out long number) || number < short.MinValue || number > short.MaxValue)
+                    return false;
 
-                if(type == typeof(BAC_Type0.EanTypeEnum))
-                {
-                    if (!ParseEnum<BAC_Type0.EanTypeEnum>(value, type, ref ret)) return false;
-                }
-                if (type == typeof(BAC_Type10.EanTypeEnum))
-                {
-                    if (!ParseEnum<BAC_Type10.EanTypeEnum>(value, type, ref ret)) return false;
-                }
-                if (type == typeof(BoneLinks))
-                {
-                    if (!ParseEnum<BoneLinks>(value, type, ref ret)) return false;
-                }
-                if (type == typeof(AcbType))
-                {
-                    if (!ParseEnum<AcbType>(value, type, ref ret)) return false;
-                }
-                if (type == typeof(BcsPartId))
-                {
-                    if (!ParseEnum<BcsPartId>(value, type, ref ret)) return false;
-                }
-                if (type == typeof(AuraType))
-                {
-                    if (!ParseEnum<AuraType>(value, type, ref ret)) return false;
-                }
-                if (type == typeof(TargetingAxis))
-                {
-                    if (!ParseEnum<TargetingAxis>(value, type, ref ret)) return false;
-                }
-                if (type == typeof(BAC_Type8.EepkTypeEnum))
-                {
-                    if (!ParseEnum<BAC_Type8.EepkTypeEnum>(value, type, ref ret)) return false;
-                }
-                if (type == typeof(BAC_Type20.HomingType))
-                {
-                    if (!ParseEnum<BAC_Type20.HomingType>(value, type, ref ret)) return false;
-                }
-                if (type == typeof(BAC_Type1.BoundingBoxTypeEnum))
-                {
-                    if (!ParseEnum<BAC_Type1.BoundingBoxTypeEnum>(value, type, ref ret)) return false;
-                }
+                result = (short)number;
+            }
+            else if (type.IsUInt16())
+            {
+                if (!TryParseInteger(value, out long number) || number < ushort.MinValue || number > ushort.MaxValue)
+                    return false;
 
-                result = ret;
+                result = (ushort)number;
+            }
+            else if (type.IsInt32())
+            {
+                if (!TryParseInteger(value, out long number) || number < int.MinValue || number > int.MaxValue)
+                    return false;
+
+                result = (int)number;
+            }
+            else if (type.IsUInt32())
+            {
+                if (!TryParseInteger(value, out long number) || number < uint.MinValue || number > uint.MaxValue)
+                    return false;
+
+                result = (uint)number;
+            }
+            else if (type.IsInt64())
+            {
+                if (!TryParseInteger(value, out long number))
+                    return false;
+
+                result = number;
+            }
+            else if (type == typeof(ulong))
+            {
+                if (!TryParseInteger(value, out long number) || number < 0)
+                    return false;
+
+                result = (ulong)number;
+            }
+            else
+            {
+                return false;
             }
 
             return true;
         }
 
-        private bool ParseEnum<T>(string value, Type type, ref object result) where T : struct, IConvertible
+        private static bool TryParseInteger(string value, out long result)
         {
-            T ret;
-            if (!Enum.TryParse(value, out ret))
-                return false;
+            if (value.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+                return long.TryParse(value.Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out result);
 
-            result = ret;
-
-            return true;
+            return long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
         }
 
         private string CreateValueToolTipForEnum()


### PR DESCRIPTION
Adds a BCM editor with a state tree view, plus fixes for editing the tree and for values that sometimes did not commit when you moved off a field. Depends on XV2-Tools bcm-support-xenokit.