### PR TITLE
Add BAC BPE screen effect preview

### DIFF
--- a/XenoKit/Editor/Files/Files.Load.cs
+++ b/XenoKit/Editor/Files/Files.Load.cs
@@ -12,6 +12,7 @@ using Xv2CoreLib.ACB;
 using Xv2CoreLib.BAC;
 using Xv2CoreLib.BCS;
 using Xv2CoreLib.BDM;
+using Xv2CoreLib.BPE;
 using Xv2CoreLib.BSA;
 using Xv2CoreLib.CUS;
 using Xv2CoreLib.EAN;
@@ -236,6 +237,8 @@ namespace XenoKit.Editor
                 move.SetName("CMN");
                 move.MoveType = Move.Type.CMN;
                 move.Files = new Xv2MoveFiles();
+
+                CmnBpeFile = BPE_File.Load(file.Instance.GetBytesFromGame("pe/cmn.bpe", false, true));
 
                 move.Files.BdmFile = new Xv2File<BDM_File>((BDM_File)file.Instance.GetParsedFileFromGame(xv2.CMN_BDM_PATH), file.Instance.GetAbsolutePath(xv2.CMN_BDM_PATH), false, null, false, xv2.MoveFileTypes.BDM, 0, true, xv2.MoveType.Common);
                 move.Files.BsaFile = new Xv2File<BSA_File>((BSA_File)file.Instance.GetParsedFileFromGame(xv2.CMN_BSA_PATH), file.Instance.GetAbsolutePath(xv2.CMN_BSA_PATH), false, null, false, xv2.MoveFileTypes.BSA, 0, true, xv2.MoveType.Common);

--- a/XenoKit/Editor/Files/Files.Lookup.cs
+++ b/XenoKit/Editor/Files/Files.Lookup.cs
@@ -12,6 +12,7 @@ using Xv2CoreLib.ACB;
 using Xv2CoreLib.BAC;
 using Xv2CoreLib.BCS;
 using Xv2CoreLib.BDM;
+using Xv2CoreLib.BPE;
 using Xv2CoreLib.BSA;
 using Xv2CoreLib.CUS;
 using Xv2CoreLib.EAN;
@@ -40,6 +41,16 @@ namespace XenoKit.Editor
         {
             var move = OutlinerItems.FirstOrDefault(x => x.Type == OutlinerItem.OutlinerItemType.CMN);
             return move != null ? move.move : null;
+        }
+
+        public BPE_Entry GetBpeEntry(ushort bpeIndex, bool logErrors)
+        {
+            BPE_Entry entry = CmnBpeFile?.Entries?.FirstOrDefault(x => x.SortID == bpeIndex);
+
+            if (entry == null && logErrors)
+                Log.Add($"Files.GetBpeEntry: Could not find BPE entry {bpeIndex}.", LogType.Warning);
+
+            return entry;
         }
 
         public List<Actor> GetLoadedCharacters()

--- a/XenoKit/Editor/Files/Files.cs
+++ b/XenoKit/Editor/Files/Files.cs
@@ -12,6 +12,7 @@ using Xv2CoreLib.ACB;
 using Xv2CoreLib.BAC;
 using Xv2CoreLib.BCS;
 using Xv2CoreLib.BDM;
+using Xv2CoreLib.BPE;
 using Xv2CoreLib.BSA;
 using Xv2CoreLib.CUS;
 using Xv2CoreLib.EAN;
@@ -61,6 +62,8 @@ namespace XenoKit.Editor
         private MainWindow window = null;
         private readonly Dictionary<string, EffectContainerFile> stageEepkCache = new Dictionary<string, EffectContainerFile>();
         private readonly HashSet<string> missingStageEepks = new HashSet<string>();
+
+        private BPE_File CmnBpeFile;
 
         public AsyncObservableCollection<OutlinerItem> OutlinerItems { get; set; } = new AsyncObservableCollection<OutlinerItem>();
 

--- a/XenoKit/Engine/Character/Actor.cs
+++ b/XenoKit/Engine/Character/Actor.cs
@@ -12,6 +12,7 @@ using Microsoft.Xna.Framework;
 using Xv2CoreLib.FPF;
 using Matrix4x4 = System.Numerics.Matrix4x4;
 using SimdVector3 = System.Numerics.Vector3;
+using SimdVector4 = System.Numerics.Vector4;
 
 namespace XenoKit.Engine
 {
@@ -189,6 +190,10 @@ namespace XenoKit.Engine
         public void ResetState(bool keepAnimation = false)
         {
             ShaderParameters.ShaderPath = ActorShaderPath.Default;
+            ShaderParameters.BodyOutlineActive = false;
+            ShaderParameters.BodyOutlineColor = SimdVector4.Zero;
+            ShaderParameters.BodyOutlineParam2 = SimdVector4.Zero;
+            ShaderParameters.BodyOutlineParam3 = SimdVector4.Zero;
             BdmTimeScaleDuration = 0;
             BdmTimeScale = 1f;
             BacTimeScale = 1f;

--- a/XenoKit/Engine/Character/PartSets.cs
+++ b/XenoKit/Engine/Character/PartSets.cs
@@ -1460,7 +1460,7 @@ namespace XenoKit.Engine
         {
             if (Model != null)
             {
-                Model.Draw(chara.Transform, 0, normalPass ? RenderSystem.NORMAL_FADE_WATERDEPTH_W_M : RenderSystem.ShadowModel_W, Skeleton);
+                Model.Draw(chara.Transform, chara.ActorSlot, normalPass ? RenderSystem.NORMAL_FADE_WATERDEPTH_W_M : RenderSystem.ShadowModel_W, Skeleton);
             }
         }
 

--- a/XenoKit/Engine/Rendering/ParticleBatch.cs
+++ b/XenoKit/Engine/Rendering/ParticleBatch.cs
@@ -28,6 +28,7 @@ namespace XenoKit.Engine.Rendering
         // D3D then fails to build the input layout and throws when the particles are drawn. Materials that fail once
         // are tracked here and skipped, so one bad material can't take down the render loop.
         private static readonly HashSet<Xv2ShaderEffect> incompatibleMaterials = new HashSet<Xv2ShaderEffect>();
+        private static readonly BlendState subtractiveBlendState = CreateSubtractiveBlendState();
 
         public readonly ParticleNode ParticleNode;
         public readonly ParticleEmissionData EmissionData;
@@ -158,6 +159,12 @@ namespace XenoKit.Engine.Rendering
                 EmissionData.Material.SetGlareOutputAllowed(!NoGlare);
                 pass.Apply();
 
+                if (EmissionData.Material.MatParam.AlphaBlendType == 2)
+                {
+                    GraphicsDevice.BlendState = subtractiveBlendState;
+                    GraphicsDevice.DepthStencilState = DepthStencilState.None;
+                }
+
                 try
                 {
                     GraphicsDevice.DrawUserPrimitives(PrimitiveType.TriangleList, Vertices, 0, batchIndex * 2);
@@ -171,6 +178,14 @@ namespace XenoKit.Engine.Rendering
             }
 
             batchIndex = 0;
+        }
+
+        private static BlendState CreateSubtractiveBlendState()
+        {
+            BlendState blendState = new BlendState { IndependentBlendEnable = true };
+            blendState.ApplySubtractive(0);
+            blendState.ApplySubtractive(1);
+            return blendState;
         }
 
         private void UpdateVertices()

--- a/XenoKit/Engine/Rendering/PostFilter.cs
+++ b/XenoKit/Engine/Rendering/PostFilter.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
-using System.Reflection;
 using XenoKit.Engine.Shader;
 using XenoKit.Engine.Vertex;
 
@@ -126,6 +125,17 @@ namespace XenoKit.Engine.Rendering
             SetUV(index);
         }
 
+        public void SetNineConeOffsets(float u, float v)
+        {
+            SetTextureCoordinates(u, v);
+        }
+
+        public void SetVertexColor(Color color)
+        {
+            for (int i = 0; i < vertices.Length; i++)
+                vertices[i].Color = color;
+        }
+
         public void SetTextureCoordinates(Vector2[] coords, int index)
         {
             if (coords.Length != 4) throw new ArgumentException("SetTextureCoordinates: expected coords to be of length 4.");
@@ -173,7 +183,7 @@ namespace XenoKit.Engine.Rendering
             }
         }
 
-        public void Apply(PostShaderEffect effect)
+        public void Apply(PostShaderEffect effect, DepthStencilState depthStencilState = null)
         {
             VerticeUpdateCheck();
 
@@ -183,6 +193,8 @@ namespace XenoKit.Engine.Rendering
             foreach (EffectPass pass in effect.CurrentTechnique.Passes)
             {
                 pass.Apply();
+                if (depthStencilState != null)
+                    GraphicsDevice.DepthStencilState = depthStencilState;
                 DrawQuad();
             }
 
@@ -192,5 +204,6 @@ namespace XenoKit.Engine.Rendering
         {
             GraphicsDevice.DrawUserIndexedPrimitives(PrimitiveType.TriangleList, vertices, 0, 4, indices, 0, 2);
         }
+
     }
 }

--- a/XenoKit/Engine/Rendering/RenderSystem.Draw.cs
+++ b/XenoKit/Engine/Rendering/RenderSystem.Draw.cs
@@ -201,6 +201,7 @@ namespace XenoKit.Engine.Rendering
         {
             bool changed = false;
             bool hasActiveBodyOutline = false;
+            bool renderBpeEffects = SettingsManager.settings.XenoKit_BpeSimulation;
 
             for (int actorSlot = 0; actorSlot < SceneManager.NumActors; actorSlot++)
             {
@@ -208,7 +209,7 @@ namespace XenoKit.Engine.Rendering
                 int paletteIndex = 1 + actorSlot;
                 Color color = new Color(0, 0, 0, 0);
 
-                if (actor?.ShaderParameters.BodyOutlineActive == true)
+                if (renderBpeEffects && actor?.ShaderParameters.BodyOutlineActive == true)
                 {
                     hasActiveBodyOutline = true;
                     System.Numerics.Vector4 outlineColor = actor.ShaderParameters.BodyOutlineColor;
@@ -230,6 +231,9 @@ namespace XenoKit.Engine.Rendering
 
         private void ApplyScreenEffects()
         {
+            if (!SettingsManager.settings.XenoKit_BpeSimulation)
+                return;
+
             for (int actorSlot = 0; actorSlot < SceneManager.NumActors; actorSlot++)
             {
                 BacScreenEffectState state = SceneManager.Actors[actorSlot]?.ActionControl?.BacPlayer?.BacEntryInstance?.ScreenEffectState;

--- a/XenoKit/Engine/Rendering/RenderSystem.Draw.cs
+++ b/XenoKit/Engine/Rendering/RenderSystem.Draw.cs
@@ -2,10 +2,9 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using XenoKit.Editor;
 using XenoKit.Engine.Model;
+using XenoKit.Engine.Scripting.BAC;
 using XenoKit.Engine.Shader;
 using XenoKit.Inspector.InspectorEntities;
 using Xv2CoreLib.EMM;
@@ -63,6 +62,10 @@ namespace XenoKit.Engine.Rendering
             if (SceneManager.UseRenderScene)
                 RenderScene.DrawPass(true);
 
+            bool hasActiveBodyOutline = UpdateBodyOutlinePalette();
+            if (hasActiveBodyOutline)
+                CopyRenderTarget(NormalPassRT1, BodyOutlineSourceRT);
+
             //Color Pass (Chara + Stage Enviroment)
             SetRenderTargets(ColorPassRT0.RenderTarget, ColorPassRT1.RenderTarget, NormalPassRT1.RenderTarget);
             GraphicsDevice.Clear(Color.Transparent);
@@ -89,9 +92,12 @@ namespace XenoKit.Engine.Rendering
             }
 
             //Black Chara Outline Shader
-            if (SettingsManager.settings.XenoKit_UseOutlinePostEffect)
+            if (SettingsManager.settings.XenoKit_UseOutlinePostEffect || hasActiveBodyOutline)
             {
-                SetRenderTargets(ColorPassRT0.RenderTarget, ColorPassRT1.RenderTarget, NormalPassRT1.RenderTarget);
+                SetRenderTargets(
+                    ColorPassRT0.RenderTarget,
+                    ColorPassRT1.RenderTarget,
+                    hasActiveBodyOutline ? BodyOutlineSourceRT.RenderTarget : NormalPassRT1.RenderTarget);
                 GraphicsDevice.SetDepthBuffer(DepthBuffer.RenderTarget);
                 SetTexture(NormalPassRT0.RenderTarget);
                 PostFilter.Apply(AGE_TEST_EDGELINE_MRT);
@@ -132,15 +138,17 @@ namespace XenoKit.Engine.Rendering
 
             //DrawEntityList(Effects, LOW_REZ_SMOKE);
 
-            //Render EdgeLine (BPE Outline Test)
-            //SetTextures(NormalPassRT1.RenderTarget, TestOutlineTexture);
-            //PostFilter.Apply(EDGELINE_VFX);
+            if (hasActiveBodyOutline)
+            {
+                SetTextures(BodyOutlineSourceRT.RenderTarget, BodyOutlinePaletteTexture);
+                PostFilter.Apply(EDGELINE_VFX);
+            }
 
             //Apply blur filter to LowRezSmoke
             SetRenderTargets(LowRezSmokeRT0_New.RenderTarget);
             GraphicsDevice.Clear(Color.Transparent);
             SetTexture(LowRezSmokeRT0.RenderTarget);
-            PostFilter.SetTextureCoordinates(1f / (CurrentRT_Width * 2), 1f / (CurrentRT_Height * 2));
+            PostFilter.SetNineConeOffsets(1f / (CurrentRT_Width * 2), 1f / (CurrentRT_Height * 2));
             PostFilter.Apply(NineConeFilter);
 
             //Merge onto main RT
@@ -149,6 +157,8 @@ namespace XenoKit.Engine.Rendering
             SetTextures(LowRezRT0.RenderTarget, LowRezSmokeRT0_New.RenderTarget, LowRezRT1.RenderTarget, LowRezSmokeRT1.RenderTarget);
             PostFilter.SetDefaultTexCord2();
             PostFilter.Apply(AGE_MERGE_AddLowRez_AddMrt);
+
+            ApplyScreenEffects();
 
             //YBS post process effects (just glare for now)
             RenderTargetWrapper result;
@@ -185,6 +195,200 @@ namespace XenoKit.Engine.Rendering
             GraphicsDevice.SetDepthAsTexture(DepthBuffer.RenderTarget, 0);
             PostFilter.Apply(DepthToDepth);
             GraphicsDevice.Textures[0] = null;
+        }
+
+        private bool UpdateBodyOutlinePalette()
+        {
+            bool changed = false;
+            bool hasActiveBodyOutline = false;
+
+            for (int actorSlot = 0; actorSlot < SceneManager.NumActors; actorSlot++)
+            {
+                Actor actor = SceneManager.Actors[actorSlot];
+                int paletteIndex = 1 + actorSlot;
+                Color color = new Color(0, 0, 0, 0);
+
+                if (actor?.ShaderParameters.BodyOutlineActive == true)
+                {
+                    hasActiveBodyOutline = true;
+                    System.Numerics.Vector4 outlineColor = actor.ShaderParameters.BodyOutlineColor;
+                    color = new Color(outlineColor.X, outlineColor.Y, outlineColor.Z, outlineColor.W);
+                }
+
+                if (!BodyOutlinePalette[paletteIndex].Equals(color))
+                {
+                    BodyOutlinePalette[paletteIndex] = color;
+                    changed = true;
+                }
+            }
+
+            if (changed)
+                BodyOutlinePaletteTexture.SetData(BodyOutlinePalette);
+
+            return hasActiveBodyOutline;
+        }
+
+        private void ApplyScreenEffects()
+        {
+            for (int actorSlot = 0; actorSlot < SceneManager.NumActors; actorSlot++)
+            {
+                BacScreenEffectState state = SceneManager.Actors[actorSlot]?.ActionControl?.BacPlayer?.BacEntryInstance?.ScreenEffectState;
+                ApplyScreenEffects(state);
+            }
+        }
+
+        private void ApplyScreenEffects(BacScreenEffectState state)
+        {
+            if (state == null)
+                return;
+
+            bool hasScreenEffect = state.BlurAmount > 0.0001f ||
+                                   state.WhiteShineAmount > 0.0001f ||
+                                   state.HasColorMultiply ||
+                                   state.HasColorAdd ||
+                                   state.HasHue ||
+                                   Math.Abs(state.ZoomLevel) > 0.0001f;
+            if (!hasScreenEffect)
+                return;
+
+            RenderTargetWrapper source = NextColorPassRT0;
+            RenderTargetWrapper target = ScreenEffectRT;
+
+            ApplyScreenEffectSpritePass(ref source, ref target, 1f, Vector2.Zero);
+
+            if (state.BlurAmount > 0.0001f)
+            {
+                float blurU = MathHelper.Clamp(state.BlurAmount / (MathHelper.Pi * 2f), 1f / CurrentRT_Width, 0.02f);
+                float blurV = blurU * CurrentRT_Width / CurrentRT_Height;
+
+                PostFilter.SetNineConeOffsets(blurU, blurV);
+                ApplyScreenEffectPass(ref source, ref target, NineConeFilter);
+            }
+
+            if (state.HasColorMultiply)
+                ApplyDtmapsPass(ref source, ref target, DTMAP_BLEND_CST_MUL, state.ColorMultiply);
+
+            if (state.HasColorAdd)
+                ApplyDtmapsPass(ref source, ref target, DTMAP_BLEND_CST_ADD, state.ColorAdd);
+
+            if (state.WhiteShineAmount > 0.0001f)
+                ApplyDtmapsPass(ref source, ref target, DTMAP_BLEND_CST_ADD, new System.Numerics.Vector4(state.WhiteShineAmount, state.WhiteShineAmount, state.WhiteShineAmount, 0f));
+
+            if (state.HasHue)
+                ApplyHuePass(ref source, ref target, state);
+
+            if (Math.Abs(state.ZoomLevel) > 0.0001f)
+            {
+                float zoom = MathHelper.Clamp(state.ZoomLevel, -0.9f, 1f);
+                ApplyScreenEffectSpritePass(ref source, ref target, 1f + zoom, Vector2.Zero);
+            }
+
+            if (source != NextColorPassRT0)
+            {
+                ApplyScreenEffectSpritePass(ref source, ref target, 1f, Vector2.Zero);
+            }
+
+        }
+
+        private void ApplyHuePass(ref RenderTargetWrapper source, ref RenderTargetWrapper target, BacScreenEffectState state)
+        {
+            PostShaderEffect effect;
+            System.Numerics.Vector4 color = state.HueColor;
+            color.W *= state.HueStrength;
+
+            switch (state.HueMode)
+            {
+                case 2:
+                    effect = DTMAP_BLEND_CST_HUE;
+                    break;
+                case 3:
+                    effect = DTMAP_BLEND_CST_MUL;
+                    float brightness = 1f - MathHelper.Clamp(color.W, 0f, 1f);
+                    color = new System.Numerics.Vector4(brightness, brightness, brightness, 1f);
+                    break;
+                case 6:
+                    effect = DTMAP_BLEND_CST_HUE;
+                    color = new System.Numerics.Vector4(0.5f * MathHelper.Clamp(color.W, 0f, 1f), 0f, 0f, 1f);
+                    break;
+                case 7:
+                case 8:
+                    effect = DTMAP_BLEND_CST_HSV;
+                    color = new System.Numerics.Vector4(color.X, 0.5f + color.Y * 0.5f, 0.5f + color.Z * 0.5f, 1f);
+                    break;
+                default:
+                    effect = DTMAP_BLEND_CST_MUL;
+                    color = System.Numerics.Vector4.Lerp(
+                        System.Numerics.Vector4.One,
+                        new System.Numerics.Vector4(color.X, color.Y, color.Z, 1f),
+                        MathHelper.Clamp(color.W, 0f, 1f));
+                    break;
+            }
+
+            ApplyDtmapsPass(ref source, ref target, effect, color, true);
+        }
+
+        private void ApplyDtmapsPass(ref RenderTargetWrapper source, ref RenderTargetWrapper target, PostShaderEffect effect, System.Numerics.Vector4 color, bool backgroundOnly = false)
+        {
+            if (backgroundOnly)
+                CopyRenderTarget(source, target);
+
+            SetRenderTargets(target.RenderTarget);
+            GraphicsDevice.SetDepthBuffer(backgroundOnly ? DepthBuffer.RenderTarget : null);
+            SetTextures(source.RenderTarget, source.RenderTarget);
+            PostFilter.SetVertexColor(new Color(color.X, color.Y, color.Z, color.W));
+            PostFilter.Apply(effect, backgroundOnly ? BackgroundOnlyDepthState : null);
+            PostFilter.SetVertexColor(Color.White);
+            SwapScreenEffectTargets(ref source, ref target);
+        }
+
+        private void ApplyScreenEffectPass(ref RenderTargetWrapper source, ref RenderTargetWrapper target, PostShaderEffect effect)
+        {
+            SetRenderTargets(target.RenderTarget);
+            GraphicsDevice.SetDepthBuffer(null);
+            SetTexture(source.RenderTarget);
+            PostFilter.Apply(effect);
+            SwapScreenEffectTargets(ref source, ref target);
+        }
+
+        private void ApplyScreenEffectSpritePass(ref RenderTargetWrapper source, ref RenderTargetWrapper target, float scale, Vector2 offset)
+        {
+            SetRenderTargets(target.RenderTarget);
+            GraphicsDevice.SetDepthBuffer(null);
+            GraphicsDevice.Clear(Color.Transparent);
+
+            Vector2 targetCenter = new Vector2(target.Width * 0.5f, target.Height * 0.5f);
+            Vector2 sourceOrigin = new Vector2(source.Width * 0.5f, source.Height * 0.5f);
+            Vector2 position = targetCenter + new Vector2(offset.X * target.Width, offset.Y * target.Height);
+
+            SpriteBatch.Begin(
+                blendState: BlendState.Opaque,
+                samplerState: SamplerState.LinearClamp,
+                depthStencilState: DepthStencilState.None);
+            SpriteBatch.Draw(source.RenderTarget, position, null, Color.White, 0f, sourceOrigin, scale, SpriteEffects.None, 0f);
+            SpriteBatch.End();
+
+            SwapScreenEffectTargets(ref source, ref target);
+        }
+
+        private void CopyRenderTarget(RenderTargetWrapper source, RenderTargetWrapper target)
+        {
+            SetRenderTargets(target.RenderTarget);
+            GraphicsDevice.SetDepthBuffer(null);
+            GraphicsDevice.Clear(Color.Transparent);
+
+            SpriteBatch.Begin(
+                blendState: BlendState.Opaque,
+                samplerState: SamplerState.PointClamp,
+                depthStencilState: DepthStencilState.None);
+            SpriteBatch.Draw(source.RenderTarget, new Rectangle(0, 0, target.Width, target.Height), Color.White);
+            SpriteBatch.End();
+        }
+
+        private static void SwapScreenEffectTargets(ref RenderTargetWrapper source, ref RenderTargetWrapper target)
+        {
+            RenderTargetWrapper oldSource = source;
+            source = target;
+            target = oldSource;
         }
 
         public void SetTexture(Texture texture, int textureSlot = 0)

--- a/XenoKit/Engine/Rendering/RenderSystem.cs
+++ b/XenoKit/Engine/Rendering/RenderSystem.cs
@@ -76,6 +76,7 @@ namespace XenoKit.Engine.Rendering
         //Characters are drawn onto these RTs using the shader NORMAL_FADE_WATERDEPTH_W_M
         private RenderTargetWrapper NormalPassRT0;
         private RenderTargetWrapper NormalPassRT1;
+        private RenderTargetWrapper BodyOutlineSourceRT;
 
         //Characters and the stage enviroments are drawn onto these RTs using their proper materials
         private RenderTargetWrapper ColorPassRT0;
@@ -85,8 +86,8 @@ namespace XenoKit.Engine.Rendering
         //The remaining stage elements are then drawn to this RT and ColorPassRT1
         private RenderTargetWrapper NextColorPassRT0;
 
-        //Some BPE effects such as BodyOutline are done at this point, and drawn onto NextColorPassRT0 + ColorPassRT1
-        //Next are effects, using the same RTs
+        //Post effects use the full-resolution color target after the low-resolution merge.
+        private RenderTargetWrapper ScreenEffectRT;
         private RenderTargetWrapper LowRezRT0;
         private RenderTargetWrapper LowRezRT1;
         private RenderTargetWrapper LowRezSmokeRT0;
@@ -115,14 +116,18 @@ namespace XenoKit.Engine.Rendering
         private PostShaderEffect DepthToDepth;
         private PostShaderEffect NineConeFilter;
         private PostShaderEffect AGE_MERGE_AddLowRez_AddMrt;
-        private PostShaderEffect Sampler0;
         private PostShaderEffect EDGELINE_VFX;
         private PostShaderEffect AGE_TEST_DEPTH_TO_PFXD;
+        private PostShaderEffect DTMAP_BLEND_CST_ADD;
+        private PostShaderEffect DTMAP_BLEND_CST_MUL;
+        private PostShaderEffect DTMAP_BLEND_CST_HUE;
+        private PostShaderEffect DTMAP_BLEND_CST_HSV;
         private PostShaderEffect DepthToColor;
         private PostShaderEffect AddTex; //Merge up to 2 textures into a RenderTarget
 
-        //private Texture2D TestOutlineTexture;
-        //private Texture2D TestOutlineTexture2;
+        private Texture2D BodyOutlinePaletteTexture;
+        private readonly Color[] BodyOutlinePalette = new Color[16 * 16];
+        private DepthStencilState BackgroundOnlyDepthState;
 
         public RenderSystem(SpriteBatch spriteBatch, bool createInternalResources)
         {
@@ -134,9 +139,6 @@ namespace XenoKit.Engine.Rendering
 
             if (createInternalResources)
                 CreateInternalResources();
-
-            //TestOutlineTexture = Textures.TextureLoader.ConvertToTexture2D(SettingsManager.Instance.GetAbsPathInAppFolder("EdgeLineTest.dds"), GraphicsDevice);
-            //TestOutlineTexture2 = Textures.TextureLoader.ConvertToTexture2D(SettingsManager.Instance.GetAbsPathInAppFolder("EdgeLineTest2.dds"), GraphicsDevice);
 
             if(ShaderManager.IsExtShadersLoaded)
                 YBS = new YBSPostProcess(this, NextColorPassRT0, ColorPassRT1);
@@ -168,9 +170,12 @@ namespace XenoKit.Engine.Rendering
             AddTex = CompiledObjectManager.GetCompiledObject<PostShaderEffect>(ShaderManager.GetShaderProgram("AddTex"));
             NineConeFilter = CompiledObjectManager.GetCompiledObject<PostShaderEffect>(ShaderManager.GetShaderProgram("NineConeFilter"));
             AGE_MERGE_AddLowRez_AddMrt = CompiledObjectManager.GetCompiledObject<PostShaderEffect>(ShaderManager.GetShaderProgram("AGE_MERGE_AddLowRez_AddMrt"));
-            Sampler0 = CompiledObjectManager.GetCompiledObject<PostShaderEffect>(ShaderManager.GetShaderProgram("Sampler0"));
             EDGELINE_VFX = CompiledObjectManager.GetCompiledObject<PostShaderEffect>(ShaderManager.GetShaderProgram("EDGELINE_VFX"));
             AGE_TEST_DEPTH_TO_PFXD = CompiledObjectManager.GetCompiledObject<PostShaderEffect>(ShaderManager.GetShaderProgram("AGE_TEST_DEPTH_TO_PFXD"));
+            DTMAP_BLEND_CST_ADD = CompiledObjectManager.GetCompiledObject<PostShaderEffect>(ShaderManager.GetShaderProgram("DTMAP_BLEND_CST_ADD"));
+            DTMAP_BLEND_CST_MUL = CompiledObjectManager.GetCompiledObject<PostShaderEffect>(ShaderManager.GetShaderProgram("DTMAP_BLEND_CST_MUL"));
+            DTMAP_BLEND_CST_HUE = CompiledObjectManager.GetCompiledObject<PostShaderEffect>(ShaderManager.GetShaderProgram("DTMAP_BLEND_CST_HUE"));
+            DTMAP_BLEND_CST_HSV = CompiledObjectManager.GetCompiledObject<PostShaderEffect>(ShaderManager.GetShaderProgram("DTMAP_BLEND_CST_HSV"));
 
             //Create RTs
             ReflectionRT = new RenderTargetWrapper(this, 0.25f, SurfaceFormat.Color, true, "ReflectionRT");
@@ -178,9 +183,11 @@ namespace XenoKit.Engine.Rendering
             DepthBuffer = new RenderTargetWrapper(this, 1, SurfaceFormat.Color, true);
             NormalPassRT0 = new RenderTargetWrapper(this, 1, SurfaceFormat.Color, true, "NormalPassRT0");
             NormalPassRT1 = new RenderTargetWrapper(this, 1, SurfaceFormat.Color, false, "NormalPassRT1");
+            BodyOutlineSourceRT = new RenderTargetWrapper(this, 1, SurfaceFormat.Color, false, "BodyOutlineSourceRT");
             ColorPassRT0 = new RenderTargetWrapper(this, 1, SurfaceFormat.Color, true, "ColorPassRT0");
             ColorPassRT1 = new RenderTargetWrapper(this, 1, SurfaceFormat.Color, false, "ColorPassRT1");
             NextColorPassRT0 = new RenderTargetWrapper(this, 1, SurfaceFormat.Color, true, "NextColorPassRT0");
+            ScreenEffectRT = new RenderTargetWrapper(this, 1, SurfaceFormat.Color, false, "ScreenEffectRT");
             FinalRenderTarget = new RenderTargetWrapper(this, 1, SurfaceFormat.Color, true, "FinalRenderTarget");
             SamplerAlphaDepth = new RenderTargetWrapper(this, 1, SurfaceFormat.Single, false, "SamplerAlphaDepth");
             LowRezRT0 = new RenderTargetWrapper(this, 0.5f, SurfaceFormat.Color, true, "LowRezRT0");
@@ -190,6 +197,19 @@ namespace XenoKit.Engine.Rendering
             LowRezSmokeRT1 = new RenderTargetWrapper(this, 0.25f, SurfaceFormat.Color, false, "LowRezSmokeRT1");
             ScreenshotRT = new RenderTargetWrapper(this, 1, SurfaceFormat.Color, true, "ScreenshotRT");
             SmallSceneRT = new RenderTargetWrapper(this, 0.25f, SurfaceFormat.Color, true, "SmallSceneRT");
+            BodyOutlinePaletteTexture = new Texture2D(GraphicsDevice, 16, 16, false, SurfaceFormat.Color);
+            BodyOutlinePaletteTexture.SetData(BodyOutlinePalette);
+            BackgroundOnlyDepthState = new DepthStencilState
+            {
+                DepthBufferEnable = false,
+                DepthBufferWriteEnable = false,
+                StencilEnable = true,
+                StencilMask = 80,
+                StencilWriteMask = 0,
+                ReferenceStencil = 80,
+                StencilFunction = CompareFunction.NotEqual,
+                CounterClockwiseStencilFunction = CompareFunction.NotEqual
+            };
 
 
             //Register all render targets so they get auto-updated if the viewport changes size
@@ -197,9 +217,11 @@ namespace XenoKit.Engine.Rendering
             RegisterRenderTarget(ShadowPassRT0);
             RegisterRenderTarget(NormalPassRT0);
             RegisterRenderTarget(NormalPassRT1);
+            RegisterRenderTarget(BodyOutlineSourceRT);
             RegisterRenderTarget(ColorPassRT0);
             RegisterRenderTarget(ColorPassRT1);
             RegisterRenderTarget(NextColorPassRT0);
+            RegisterRenderTarget(ScreenEffectRT);
             RegisterRenderTarget(FinalRenderTarget);
             RegisterRenderTarget(SamplerAlphaDepth);
             RegisterRenderTarget(LowRezRT0);
@@ -278,9 +300,6 @@ namespace XenoKit.Engine.Rendering
             DumpRenderTargetsNextFrame = false;
             bool dumpShadowMap = DumpShadowMapNextFrame;
             DumpShadowMapNextFrame = false;
-
-            //TestOutlineTexture = Textures.TextureLoader.ConvertToTexture2D(SettingsManager.Instance.GetAbsPathInAppFolder("EdgeLineTest.dds"), GraphicsDevice);
-            //return;
 
             Directory.CreateDirectory(SettingsManager.Instance.GetAbsPathInAppFolder("RT_Dump"));
 

--- a/XenoKit/Engine/Scripting/BAC/BacEntryInstance.cs
+++ b/XenoKit/Engine/Scripting/BAC/BacEntryInstance.cs
@@ -5,9 +5,11 @@ using XenoKit.Editor;
 using XenoKit.Engine.Scripting.BSA;
 using XenoKit.Engine.Scripting.BAC.Simulation;
 using Xv2CoreLib.BAC;
+using Xv2CoreLib.BPE;
 using Xv2CoreLib.BSA;
 using Xv2CoreLib.EAN;
 using Matrix4x4 = System.Numerics.Matrix4x4;
+using SimdVector4 = System.Numerics.Vector4;
 
 namespace XenoKit.Engine.Scripting.BAC
 {
@@ -64,6 +66,10 @@ namespace XenoKit.Engine.Scripting.BAC
         private readonly Dictionary<BAC_Type9, float> loopProjectileSpawnFrames = new Dictionary<BAC_Type9, float>();
         private readonly List<float> activeBsaPassConditions = new List<float>();
         private const float BsaConditionTolerance = 0.001f;
+
+        private readonly Dictionary<ushort, BacScreenEffectInstance> activeScreenEffects = new Dictionary<ushort, BacScreenEffectInstance>();
+        internal IEnumerable<BacScreenEffectInstance> ActiveScreenEffects => activeScreenEffects.Values;
+        public BacScreenEffectState ScreenEffectState { get; } = new BacScreenEffectState();
 
         /// <summary>
         /// The currently active eye movement entry. Only one of these can be active at any given time.
@@ -323,6 +329,7 @@ namespace XenoKit.Engine.Scripting.BAC
         {
             ClearVisualObjects();
             ClearProjectiles();
+            ClearScreenEffect();
 
             IsFinished = false;
             ActiveEyeMovement = null;
@@ -348,7 +355,62 @@ namespace XenoKit.Engine.Scripting.BAC
             InScope = false;
             ClearVisualObjects();
             ClearProjectiles();
+            ClearScreenEffect();
             ClearActiveBsaPassConditions();
+        }
+
+        public void StartScreenEffect(BPE_Entry bpeEntry, BAC_Type16 screenEffect)
+        {
+            ushort bpeIndex = checked((ushort)bpeEntry.SortID);
+            activeScreenEffects[bpeIndex] = new BacScreenEffectInstance(
+                bpeEntry,
+                screenEffect.ScreenEffectFlags,
+                (int)CurrentFrame);
+        }
+
+        public void ClearScreenEffect(BAC_Type16 screenEffect)
+        {
+            ushort bpeIndex = screenEffect.BpeIndex;
+            if (activeScreenEffects.TryGetValue(bpeIndex, out BacScreenEffectInstance activeEffect) &&
+                GetScreenEffectMatchFlags(activeEffect.ScreenEffectFlags) == GetScreenEffectMatchFlags(screenEffect.ScreenEffectFlags))
+            {
+                ClearScreenEffect(bpeIndex);
+            }
+        }
+
+        public void ClearScreenEffect(ushort bpeIndex)
+        {
+            activeScreenEffects.Remove(bpeIndex);
+
+            if (activeScreenEffects.Count == 0)
+            {
+                ScreenEffectState.Clear();
+                ClearBodyOutlineValues();
+            }
+        }
+
+        public void ClearScreenEffect()
+        {
+            activeScreenEffects.Clear();
+            ScreenEffectState.Clear();
+
+            ClearBodyOutlineValues();
+        }
+
+        public void ClearBodyOutlineValues()
+        {
+            if (Actor != null)
+            {
+                Actor.ShaderParameters.BodyOutlineActive = false;
+                Actor.ShaderParameters.BodyOutlineColor = SimdVector4.Zero;
+                Actor.ShaderParameters.BodyOutlineParam2 = SimdVector4.Zero;
+                Actor.ShaderParameters.BodyOutlineParam3 = SimdVector4.Zero;
+            }
+        }
+
+        private static BAC_Type16.ScreenEffectFlagsEnum GetScreenEffectMatchFlags(BAC_Type16.ScreenEffectFlagsEnum flags)
+        {
+            return flags & ~BAC_Type16.ScreenEffectFlagsEnum.DisableEffect;
         }
 
         public void AddVisualObject(BAC_Type1 hitbox, Viewport game)
@@ -452,6 +514,50 @@ namespace XenoKit.Engine.Scripting.BAC
             Projectiles.Clear();
             spawnedProjectileTypes.Clear();
             loopProjectileSpawnFrames.Clear();
+        }
+    }
+
+    internal sealed class BacScreenEffectInstance
+    {
+        public BPE_Entry Entry { get; private set; }
+        public BAC_Type16.ScreenEffectFlagsEnum ScreenEffectFlags { get; private set; }
+        public int StartFrame { get; private set; }
+
+        public BacScreenEffectInstance(BPE_Entry entry, BAC_Type16.ScreenEffectFlagsEnum screenEffectFlags, int startFrame)
+        {
+            Entry = entry;
+            ScreenEffectFlags = screenEffectFlags;
+            StartFrame = startFrame;
+        }
+    }
+
+    public sealed class BacScreenEffectState
+    {
+        public float BlurAmount;
+        public float WhiteShineAmount;
+        public System.Numerics.Vector4 ColorMultiply = SimdVector4.One;
+        public System.Numerics.Vector4 ColorAdd;
+        public bool HasColorMultiply;
+        public bool HasColorAdd;
+        public int HueMode = -1;
+        public System.Numerics.Vector4 HueColor;
+        public float HueStrength = 1f;
+        public bool HasHue;
+        public float ZoomLevel;
+
+        public void Clear()
+        {
+            BlurAmount = 0f;
+            WhiteShineAmount = 0f;
+            ColorMultiply = SimdVector4.One;
+            ColorAdd = SimdVector4.Zero;
+            HasColorMultiply = false;
+            HasColorAdd = false;
+            HueMode = -1;
+            HueColor = SimdVector4.Zero;
+            HueStrength = 1f;
+            HasHue = false;
+            ZoomLevel = 0f;
         }
     }
 

--- a/XenoKit/Engine/Scripting/BAC/BacPlayer.cs
+++ b/XenoKit/Engine/Scripting/BAC/BacPlayer.cs
@@ -19,6 +19,7 @@ namespace XenoKit.Engine.Scripting.BAC
     {
         //Parent character that this BacPlayer is for
         private readonly Actor character;
+        private readonly BacScreenEffectEvaluator screenEffectEvaluator;
 
         //Bac Entry:
         public BacEntryInstance BacEntryInstance { get; private set; }
@@ -66,6 +67,7 @@ namespace XenoKit.Engine.Scripting.BAC
         public BacPlayer(Actor chara)
         {
             character = chara;
+            screenEffectEvaluator = new BacScreenEffectEvaluator(chara);
             Xv2CoreLib.Resource.UndoRedo.UndoManager.Instance.UndoOrRedoCalled += Instance_UndoOrRedoCalled;
         }
 
@@ -257,6 +259,25 @@ namespace XenoKit.Engine.Scripting.BAC
                     }
                 }
 
+                //Screen effect
+                if (type is BAC_Type16 screenEffect)
+                {
+                    bool allowLoop = (screenEffect.ScreenEffectFlags & BAC_Type16.ScreenEffectFlagsEnum.AllowLoop) == BAC_Type16.ScreenEffectFlagsEnum.AllowLoop;
+
+                    if (!allowLoop && type.TimesActivated > 0) continue;
+                    if (!ActivationCheck(type)) continue;
+
+                    if ((screenEffect.ScreenEffectFlags & BAC_Type16.ScreenEffectFlagsEnum.DisableEffect) == BAC_Type16.ScreenEffectFlagsEnum.DisableEffect)
+                    {
+                        BacEntryInstance.ClearScreenEffect(screenEffect);
+                        continue;
+                    }
+
+                    Xv2CoreLib.BPE.BPE_Entry bpeEntry = Files.Instance.GetBpeEntry(screenEffect.BpeIndex, true);
+                    if (screenEffectEvaluator.HasData(bpeEntry))
+                        BacEntryInstance.StartScreenEffect(bpeEntry, screenEffect);
+                }
+
                 //Projectile
                 if (type is BAC_Type9 projectile)
                 {
@@ -391,6 +412,8 @@ namespace XenoKit.Engine.Scripting.BAC
                     //character.ShaderParameters.g_vParam9_PS = new Vector4(0, 10, 0, 30);
                 }
             }
+
+            screenEffectEvaluator.Update(BacEntryInstance, CurrentFrame);
 
             //Update Eye Movements
             if (BacEntryInstance.ActiveEyeMovement != null)
@@ -536,6 +559,8 @@ namespace XenoKit.Engine.Scripting.BAC
                     while (character.Controller.FreezeActionFrames > 0);
                 }
             }
+
+            screenEffectEvaluator.Update(BacEntryInstance, CurrentFrame);
 
             //Reset camera state if no cam anim is active. This allows the bac entry to be paused, then the camera moved, and the scene to resume without the camera resetting to the last simulated camera
             if (Viewport.Instance.Camera.cameraInstance == null && SceneManager.UseCameras)
@@ -748,6 +773,7 @@ namespace XenoKit.Engine.Scripting.BAC
 
             VfxManager.ForceEffectUpdate = true;
             VfxManager.Simulate();
+            screenEffectEvaluator.Update(BacEntryInstance, CurrentFrame);
         }
         #endregion
 

--- a/XenoKit/Engine/Scripting/BAC/BacScreenEffectEvaluator.cs
+++ b/XenoKit/Engine/Scripting/BAC/BacScreenEffectEvaluator.cs
@@ -1,0 +1,368 @@
+using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xv2CoreLib.BPE;
+using SimdVector4 = System.Numerics.Vector4;
+
+namespace XenoKit.Engine.Scripting.BAC
+{
+    internal sealed class BacScreenEffectEvaluator
+    {
+        private readonly Actor character;
+
+        public BacScreenEffectEvaluator(Actor character)
+        {
+            this.character = character;
+        }
+
+        public void Update(BacEntryInstance bacEntryInstance, int currentFrame)
+        {
+            BacScreenEffectState state = bacEntryInstance.ScreenEffectState;
+            state.Clear();
+
+            List<ushort> expiredEffects = null;
+            int latestBodyOutlineStartFrame = int.MinValue;
+            bool hasBodyOutline = false;
+
+            foreach (BacScreenEffectInstance activeEffect in bacEntryInstance.ActiveScreenEffects)
+            {
+                BPE_Entry bpeEntry = activeEffect.Entry;
+                int frame = currentFrame - activeEffect.StartFrame;
+                bool isLooping = IsLooping(bpeEntry);
+
+                if (!isLooping && bpeEntry.I_04 > 0 && frame > bpeEntry.I_04)
+                {
+                    if (expiredEffects == null)
+                        expiredEffects = new List<ushort>();
+
+                    expiredEffects.Add((ushort)bpeEntry.SortID);
+                    continue;
+                }
+
+                int evaluationFrame = isLooping ? frame % bpeEntry.I_04 : frame;
+                if (bpeEntry.SubEntries != null)
+                {
+                    foreach (BPE_SubEntry subEntry in bpeEntry.SubEntries)
+                    {
+                        if (!IsBpeSubEntryActive(subEntry, evaluationFrame))
+                            continue;
+
+                        switch ((int)subEntry.BpeType)
+                        {
+                            case 0:
+                                UpdateBlurState(subEntry, evaluationFrame, state);
+                                break;
+                            case 1:
+                                UpdateWhiteShineState(subEntry, evaluationFrame, state);
+                                break;
+                            case 2:
+                                UpdateType2State(subEntry, evaluationFrame, state);
+                                break;
+                            case 3:
+                                UpdateType3State(subEntry, evaluationFrame, state);
+                                break;
+                            case 6:
+                                UpdateZoomState(subEntry, evaluationFrame, state);
+                                break;
+                            case 7:
+                                UpdateType7State(subEntry, evaluationFrame, state);
+                                break;
+                            case 8:
+                                UpdateHueState(subEntry, evaluationFrame, state);
+                                break;
+                        }
+                    }
+                }
+
+                if (activeEffect.StartFrame >= latestBodyOutlineStartFrame &&
+                    TryUpdateBodyOutline(bpeEntry, evaluationFrame))
+                {
+                    latestBodyOutlineStartFrame = activeEffect.StartFrame;
+                    hasBodyOutline = true;
+                }
+            }
+
+            if (expiredEffects != null)
+            {
+                foreach (ushort bpeIndex in expiredEffects)
+                    bacEntryInstance.ClearScreenEffect(bpeIndex);
+            }
+
+            if (!hasBodyOutline)
+                bacEntryInstance.ClearBodyOutlineValues();
+        }
+
+        public bool HasData(BPE_Entry bpeEntry)
+        {
+            if (bpeEntry?.SubEntries == null)
+                return false;
+
+            foreach (BPE_SubEntry subEntry in bpeEntry.SubEntries)
+            {
+                switch ((int)subEntry.BpeType)
+                {
+                    case 0:
+                        if (subEntry.Type0?.Count > 0) return true;
+                        break;
+                    case 1:
+                        if (subEntry.Type1?.Count > 0) return true;
+                        break;
+                    case 2:
+                        if (subEntry.Type2?.Count > 0) return true;
+                        break;
+                    case 3:
+                        if (subEntry.Type3?.Count > 0) return true;
+                        break;
+                    case 6:
+                        if (subEntry.Type6?.Count > 0) return true;
+                        break;
+                    case 7:
+                        if (subEntry.Type7?.Count > 0) return true;
+                        break;
+                    case 8:
+                        if (subEntry.Type8?.Count > 0) return true;
+                        break;
+                    case 9:
+                        if (subEntry.Type9?.Count > 0) return true;
+                        break;
+                }
+            }
+
+            return false;
+        }
+
+        private bool TryUpdateBodyOutline(BPE_Entry bpeEntry, int frame)
+        {
+            BPE_SubEntry bodyOutline = bpeEntry?.SubEntries?.FirstOrDefault(x => x.BpeType == BpeType.BodyOutline);
+
+            if (bodyOutline?.Type9 == null || bodyOutline.Type9.Count == 0 ||
+                frame < bodyOutline.I_04 || (bodyOutline.I_06 >= bodyOutline.I_04 && frame > bodyOutline.I_06))
+            {
+                return false;
+            }
+
+            BPE_Type9 previousKeyframe;
+            BPE_Type9 nextKeyframe;
+            float factor;
+            if (!TryGetInterpolated(bodyOutline.Type9, frame, x => x.I_00, out previousKeyframe, out nextKeyframe, out factor))
+                return false;
+
+            float paletteIndex = 1f + character.ActorSlot;
+            float transparency = MathHelper.Lerp(previousKeyframe.F_12, nextKeyframe.F_12, factor);
+            const float baseRadius = 4f;
+            const float transparencyRadiusScale = 3f;
+            const float previewRadiusScale = 0.5f;
+            float previewRadius = (baseRadius - transparencyRadiusScale * transparency) * previewRadiusScale;
+            float previewTransparency = MathHelper.Clamp((baseRadius - previewRadius) / transparencyRadiusScale, 0f, 1f);
+            character.ShaderParameters.BodyOutlineActive = true;
+            character.ShaderParameters.BodyOutlineColor = new SimdVector4(
+                MathHelper.Lerp(previousKeyframe.F_20, nextKeyframe.F_20, factor),
+                MathHelper.Lerp(previousKeyframe.F_24, nextKeyframe.F_24, factor),
+                MathHelper.Lerp(previousKeyframe.F_28, nextKeyframe.F_28, factor),
+                MathHelper.Lerp(previousKeyframe.F_32, nextKeyframe.F_32, factor));
+            character.ShaderParameters.BodyOutlineParam2 = new SimdVector4(paletteIndex / 256f, 0f, 1f, 0f);
+            character.ShaderParameters.BodyOutlineParam3 = new SimdVector4(
+                MathHelper.Lerp(previousKeyframe.F_04, nextKeyframe.F_04, factor),
+                MathHelper.Lerp(previousKeyframe.F_08, nextKeyframe.F_08, factor),
+                previewTransparency,
+                MathHelper.Lerp(previousKeyframe.F_16, nextKeyframe.F_16, factor));
+
+            return true;
+        }
+
+        private static bool IsBpeSubEntryActive(BPE_SubEntry subEntry, int frame)
+        {
+            if (frame < subEntry.I_04)
+                return false;
+
+            return subEntry.I_06 < subEntry.I_04 || frame <= subEntry.I_06;
+        }
+
+        private static bool IsLooping(BPE_Entry bpeEntry)
+        {
+            return bpeEntry != null && bpeEntry.I_00 == 1 && bpeEntry.I_04 > 0;
+        }
+
+        private static bool TryGetInterpolated<T>(IList<T> keyframes, int frame, Func<T, int> getFrame, out T previous, out T next, out float factor)
+        {
+            previous = default(T);
+            next = default(T);
+            factor = 0f;
+
+            if (keyframes == null || keyframes.Count == 0)
+                return false;
+
+            previous = keyframes[0];
+            next = previous;
+
+            if (frame <= getFrame(previous))
+                return true;
+
+            for (int i = 1; i < keyframes.Count; i++)
+            {
+                next = keyframes[i];
+                int previousFrame = getFrame(previous);
+                int nextFrame = getFrame(next);
+
+                if (frame <= nextFrame)
+                {
+                    if (nextFrame != previousFrame)
+                        factor = (frame - previousFrame) / (float)(nextFrame - previousFrame);
+
+                    return true;
+                }
+
+                previous = next;
+            }
+
+            return true;
+        }
+
+        private static void UpdateBlurState(BPE_SubEntry subEntry, int frame, BacScreenEffectState state)
+        {
+            BPE_Type0 previous;
+            BPE_Type0 next;
+            float factor;
+
+            if (TryGetInterpolated(subEntry.Type0, frame, x => x.I_00, out previous, out next, out factor))
+                state.BlurAmount = Math.Max(state.BlurAmount, Math.Abs(MathHelper.Lerp(previous.F_04, next.F_04, factor)));
+        }
+
+        private static void UpdateWhiteShineState(BPE_SubEntry subEntry, int frame, BacScreenEffectState state)
+        {
+            BPE_Type1 previous;
+            BPE_Type1 next;
+            float factor;
+
+            if (TryGetInterpolated(subEntry.Type1, frame, x => x.I_00, out previous, out next, out factor))
+            {
+                float intensity = MathHelper.Lerp(previous.F_08, next.F_08, factor);
+                float range = MathHelper.Lerp(previous.F_12, next.F_12, factor);
+                float amount = range > 0f ? intensity / range : intensity;
+                amount = MathHelper.Clamp(amount, 0f, 1f);
+                state.WhiteShineAmount = Math.Max(state.WhiteShineAmount, amount);
+            }
+        }
+
+        private static void UpdateType2State(BPE_SubEntry subEntry, int frame, BacScreenEffectState state)
+        {
+            BPE_Type2 previous;
+            BPE_Type2 next;
+            float factor;
+
+            if (!TryGetInterpolated(subEntry.Type2, frame, x => x.I_00, out previous, out next, out factor))
+                return;
+
+            SimdVector4 multiplier = new SimdVector4(
+                MathHelper.Lerp(previous.F_12, next.F_12, factor),
+                MathHelper.Lerp(previous.F_16, next.F_16, factor),
+                MathHelper.Lerp(previous.F_20, next.F_20, factor),
+                MathHelper.Lerp(previous.F_24, next.F_24, factor));
+            float amount = Math.Max(
+                Math.Abs(MathHelper.Lerp(previous.F_40, next.F_40, factor)),
+                Math.Max(
+                    Math.Abs(MathHelper.Lerp(previous.F_44, next.F_44, factor)),
+                    Math.Abs(MathHelper.Lerp(previous.F_48, next.F_48, factor))));
+
+            if (amount < 0.0001f)
+                amount = 1f;
+
+            if (multiplier != SimdVector4.One)
+            {
+                SimdVector4 blendedMultiplier = SimdVector4.Lerp(SimdVector4.One, multiplier, MathHelper.Clamp(amount, 0f, 1f));
+                state.ColorMultiply = SimdVector4.Multiply(state.ColorMultiply, blendedMultiplier);
+                state.HasColorMultiply = true;
+            }
+
+            SimdVector4 color = new SimdVector4(
+                MathHelper.Lerp(previous.F_28, next.F_28, factor),
+                MathHelper.Lerp(previous.F_32, next.F_32, factor),
+                MathHelper.Lerp(previous.F_36, next.F_36, factor),
+                0f);
+
+            if (color.X != 0f || color.Y != 0f || color.Z != 0f)
+            {
+                state.ColorAdd += color * MathHelper.Clamp(amount, 0f, 1f);
+                state.HasColorAdd = true;
+            }
+        }
+
+        private static void UpdateType3State(BPE_SubEntry subEntry, int frame, BacScreenEffectState state)
+        {
+            BPE_Type3 previous;
+            BPE_Type3 next;
+            float factor;
+
+            if (!TryGetInterpolated(subEntry.Type3, frame, x => x.I_00, out previous, out next, out factor))
+                return;
+
+            SimdVector4 multiplier = new SimdVector4(
+                MathHelper.Lerp(previous.F_08, next.F_08, factor),
+                MathHelper.Lerp(previous.F_12, next.F_12, factor),
+                MathHelper.Lerp(previous.F_16, next.F_16, factor),
+                MathHelper.Lerp(previous.F_20, next.F_20, factor));
+
+            state.ColorMultiply = SimdVector4.Multiply(state.ColorMultiply, multiplier);
+            state.HasColorMultiply = true;
+        }
+
+        private static void UpdateZoomState(BPE_SubEntry subEntry, int frame, BacScreenEffectState state)
+        {
+            BPE_Type6 previous;
+            BPE_Type6 next;
+            float factor;
+
+            if (!TryGetInterpolated(subEntry.Type6, frame, x => x.I_00, out previous, out next, out factor))
+                return;
+
+            float zoom = MathHelper.Lerp(previous.F_40, next.F_40, factor);
+            if (Math.Abs(zoom) > Math.Abs(state.ZoomLevel))
+                state.ZoomLevel = zoom;
+
+            SimdVector4 color = new SimdVector4(
+                MathHelper.Lerp(previous.F_08, next.F_08, factor),
+                MathHelper.Lerp(previous.F_12, next.F_12, factor),
+                MathHelper.Lerp(previous.F_16, next.F_16, factor),
+                0f);
+            float alpha = MathHelper.Clamp(MathHelper.Lerp(previous.F_20, next.F_20, factor), 0f, 1f);
+
+            if (alpha > 0f && (color.X != 0f || color.Y != 0f || color.Z != 0f))
+            {
+                state.ColorAdd += color * alpha;
+                state.HasColorAdd = true;
+            }
+        }
+
+        private static void UpdateType7State(BPE_SubEntry subEntry, int frame, BacScreenEffectState state)
+        {
+            BPE_Type7 previous;
+            BPE_Type7 next;
+            float factor;
+
+            if (TryGetInterpolated(subEntry.Type7, frame, x => x.I_00, out previous, out next, out factor))
+            {
+                float strength = MathHelper.Clamp(MathHelper.Lerp(previous.F_04, next.F_04, factor), 0f, 1f);
+                state.HueStrength = Math.Min(state.HueStrength, strength);
+            }
+        }
+
+        private static void UpdateHueState(BPE_SubEntry subEntry, int frame, BacScreenEffectState state)
+        {
+            BPE_Type8 previous;
+            BPE_Type8 next;
+            float factor;
+
+            if (!TryGetInterpolated(subEntry.Type8, frame, x => x.I_00, out previous, out next, out factor))
+                return;
+
+            state.HueMode = factor < 0.5f ? previous.I_08 : next.I_08;
+            state.HueColor = new SimdVector4(
+                MathHelper.Lerp(previous.F_12, next.F_12, factor),
+                MathHelper.Lerp(previous.F_16, next.F_16, factor),
+                MathHelper.Lerp(previous.F_20, next.F_20, factor),
+                MathHelper.Lerp(previous.F_24, next.F_24, factor));
+            state.HasHue = true;
+        }
+    }
+}

--- a/XenoKit/Engine/Shader/PostShaderEffect.cs
+++ b/XenoKit/Engine/Shader/PostShaderEffect.cs
@@ -16,9 +16,12 @@ namespace XenoKit.Engine.Shader
             DepthToDepth, //Copies depth from the input render target onto the current
             NineConeFilter, //Blur filter
             AGE_MERGE_AddLowRez_AddMrt, //Merges the "LowRez" render targets into another (the primary RT)
-            Sampler0, //Copy one RT (input) onto another (current), and turns alpha black (?). Probably not needed since SpriteBatch can do this
-            EDGELINE_VFX, //BPE "BodyOutline" shader. Relies on 2 inputs: NormalPassRT1 and a texture that contains the outline color (16x16, though only the second pixel on the first line is used)
+            EDGELINE_VFX, //BPE "BodyOutline" shader. Uses NormalPassRT1 and a 16x16 outline-color palette.
             AGE_TEST_DEPTH_TO_PFXD,
+            DTMAP_BLEND_CST_ADD,
+            DTMAP_BLEND_CST_MUL,
+            DTMAP_BLEND_CST_HUE,
+            DTMAP_BLEND_CST_HSV,
 
             //ExtShaders
             YBS_Copy,
@@ -41,6 +44,8 @@ namespace XenoKit.Engine.Shader
         public readonly SamplerState[] ImageSampler = new SamplerState[4];
 
         private EffectParameter g_vParam0_PS;
+        private EffectParameter g_vParam0_VS;
+        private EffectParameter g_vParam1_VS;
         private EffectParameter g_vEdge_PS;
         private EffectParameter afRGBA_Modulate;
         private EffectParameter afUV_TexCoordOffsetV16;
@@ -69,14 +74,21 @@ namespace XenoKit.Engine.Shader
             switch (Shader)
             {
                 case PostProccessShader.AGE_TEST_DEPTH_TO_PFXD:
-                    ImageSampler[0] = CreateSampler(TextureAddressMode.Clamp, TextureAddressMode.Wrap, TextureFilter.Point, 0);
+                    ImageSampler[0] = CreateSampler(TextureAddressMode.Wrap, TextureAddressMode.Wrap, TextureFilter.Point, 0);
                     break;
                 case PostProccessShader.EDGELINE_VFX:
-                    ImageSampler[0] = CreateSampler(TextureAddressMode.Clamp, TextureAddressMode.Wrap, TextureFilter.Point, 0);
-                    ImageSampler[1] = CreateSampler(TextureAddressMode.Clamp, TextureAddressMode.Wrap, TextureFilter.Point, 1);
+                    ImageSampler[0] = CreateSampler(TextureAddressMode.Clamp, TextureAddressMode.Clamp, TextureFilter.Point, 0);
+                    ImageSampler[1] = CreateSampler(TextureAddressMode.Clamp, TextureAddressMode.Clamp, TextureFilter.Point, 1);
                     break;
                 case PostProccessShader.DepthToDepth:
                     ImageSampler[0] = CreateSampler(TextureAddressMode.Clamp, TextureAddressMode.Wrap, TextureFilter.Point, 0);
+                    break;
+                case PostProccessShader.DTMAP_BLEND_CST_ADD:
+                case PostProccessShader.DTMAP_BLEND_CST_MUL:
+                case PostProccessShader.DTMAP_BLEND_CST_HUE:
+                case PostProccessShader.DTMAP_BLEND_CST_HSV:
+                    ImageSampler[0] = CreateSampler(TextureAddressMode.Clamp, TextureAddressMode.Clamp, TextureFilter.Linear, 0);
+                    ImageSampler[1] = CreateSampler(TextureAddressMode.Clamp, TextureAddressMode.Clamp, TextureFilter.Linear, 1);
                     break;
                 case PostProccessShader.YBS_Copy:
                 case PostProccessShader.YBS_Dim:
@@ -129,6 +141,8 @@ namespace XenoKit.Engine.Shader
             g_mWLP_SM_VS = Parameters["g_mWLP_SM_VS"];
 
             g_vParam0_PS = Parameters["g_vParam0_PS"];
+            g_vParam0_VS = Parameters["g_vParam0_VS"];
+            g_vParam1_VS = Parameters["g_vParam1_VS"];
             g_vParam1_PS = Parameters["g_vParam1_PS"];
             g_vEdge_PS = Parameters["g_vEdge_PS"];
             g_vScreen_VS = Parameters["g_vScreen_VS"];
@@ -180,15 +194,19 @@ namespace XenoKit.Engine.Shader
             switch (Shader)
             {
                 case PostProccessShader.EDGELINE_VFX:
-                    g_vParam0_PS?.SetValue(new Vector4(0.00104f, 0.00185f, 0.00026f, 0.00046f));
-                    g_vParam1_PS?.SetValue(new Vector4(0, 1f, 10f, 0));
+                    float inverseTargetWidth = 1f / Viewport.Instance.RenderSystem.CurrentRT_Width;
+                    float inverseTargetHeight = 1f / Viewport.Instance.RenderSystem.CurrentRT_Height;
+                    float inverseSourceWidth = 1f / Viewport.Instance.RenderSystem.RenderWidth;
+                    float inverseSourceHeight = 1f / Viewport.Instance.RenderSystem.RenderHeight;
+                    g_vParam0_PS?.SetValue(new Vector4(
+                        inverseTargetWidth,
+                        inverseTargetHeight,
+                        inverseSourceWidth,
+                        inverseSourceHeight));
+                    g_vParam1_PS?.SetValue(new Vector4(0, 1f, 7.5f, 0));
                     break;
                 case PostProccessShader.AGE_TEST_EDGELINE_MRT:
                     g_vParam0_PS?.SetValue(new Vector4(0.0f, 9, 3f, 0.6f));
-                    //Parameters["g_vParam1_PS"]?.SetValue(new Vector4(0.00039f, 0.00069f, 3f, 0.6f));
-                    //float factor = Viewport.Instance.RenderSystem.SuperSampleFactor > 1 ? 0.85f : 1f;
-                    //Parameters["g_vParam1_PS"]?.SetValue(new Vector4(0.00039f, 0.00055f, 3f, 0.6f) * factor);
-                    //Attempt to fix a weird bug where outlines disappear
                     if (Viewport.Instance.RenderSystem.SuperSampleFactor > 1)
                     {
                         g_vParam1_PS?.SetValue(new Vector4(0.000312f, 0.000552f, 2.4f, 0.5f));
@@ -201,6 +219,14 @@ namespace XenoKit.Engine.Shader
                 case PostProccessShader.AGE_TEST_DEPTH_TO_PFXD:
                     g_vParam0_PS?.SetValue(new Vector4(0.04187f, 0.95813f, 80f, 0f));
                     g_vScreen_VS?.SetValue(new Vector4(Viewport.Instance.RenderSystem.RenderWidth, Viewport.Instance.RenderSystem.RenderHeight, 0.10f, 10106.85645f));
+                    break;
+                case PostProccessShader.DTMAP_BLEND_CST_ADD:
+                case PostProccessShader.DTMAP_BLEND_CST_MUL:
+                case PostProccessShader.DTMAP_BLEND_CST_HUE:
+                case PostProccessShader.DTMAP_BLEND_CST_HSV:
+                    g_vParam0_VS?.SetValue(Vector4.One);
+                    g_vParam1_VS?.SetValue(Vector4.One);
+                    g_vParam0_PS?.SetValue(Vector4.Zero);
                     break;
                 case PostProccessShader.BIRD_BG_EDGELINE_RGB_HF:
                     g_vEdge_PS?.SetValue(new Vector4(0.1f, 0.1f, 0.1f, 5f));
@@ -270,6 +296,14 @@ namespace XenoKit.Engine.Shader
                 case PostProccessShader.AGE_MERGE_AddLowRez_AddMrt:
                     blendState.ApplyCustom(0, BlendFunction.Add, Blend.One, Blend.SourceAlpha, ColorWriteChannels.Red | ColorWriteChannels.Green | ColorWriteChannels.Blue);
                     blendState.ApplyCustom(1, BlendFunction.Add, Blend.One, Blend.SourceAlpha);
+                    break;
+                case PostProccessShader.NineConeFilter:
+                case PostProccessShader.DTMAP_BLEND_CST_ADD:
+                case PostProccessShader.DTMAP_BLEND_CST_MUL:
+                case PostProccessShader.DTMAP_BLEND_CST_HUE:
+                case PostProccessShader.DTMAP_BLEND_CST_HSV:
+                    blendState.ApplyCustom(0, BlendFunction.Add, Blend.One, Blend.Zero);
+                    blendState.ApplyNone(1);
                     break;
             }
 

--- a/XenoKit/Engine/Shader/Xv2ShaderEffect.cs
+++ b/XenoKit/Engine/Shader/Xv2ShaderEffect.cs
@@ -944,15 +944,21 @@ namespace XenoKit.Engine.Shader
 
             if (ShaderType == ShaderType.CharaNormals)
             {
-                //Controls the final vertex color of NormalPassRT0 and 1, which is key for the black body outline around characters as well as BPE BodyOutlines 
-                //g_vParam1_PS.SetValue(new Vector4(0, 50, 1, 0.6f)); //Related to RT0
-                //g_vParam2_PS.SetValue(new Vector4(0.01563f, 0, 1, 0)); //X = NormalPassRT1 B? Z is related to RT0
-                //g_vParam3_PS.SetValue(new Vector4(10f, 1000f, 0.0f, 0.0f)); //Z = NormalPassRT1 Alpha (This is 0 if no BodyOutline BPE, else some value greater than 0. Values seen: 0.92549 = chara 1, 0.4: = chara 2)
+                Actor actor = ActorSlot >= 0 && ActorSlot < SceneManager.NumActors ? SceneManager.Actors[ActorSlot] : null;
 
-                //Testing:
-                g_vParam1_PS?.SetValue(new Vector4(0f, 1, 1.0f, 0.6f)); //W = Outline strength (chara black edgeline), Y = somehow affects size of outline, default value is 50 but that looks off in XenoKit so a value of 1 is used instead
-                g_vParam2_PS?.SetValue(new Vector4(0f, 0.00f, 1.0f, 0.0f)); //X = Pixel color in main color pallete texture (0.00391 * index) (BPE)
-                g_vParam3_PS?.SetValue(new Vector4(10f, 10000.00f, 0.00f, 0.00f)); //Z = BPE Outline strength
+                g_vParam1_PS?.SetValue(new Vector4(0f, 1f, 1f, 0.6f));
+
+                if (actor?.ShaderParameters.BodyOutlineActive == true)
+                {
+                    g_vParam2_PS?.SetValue(actor.ShaderParameters.BodyOutlineParam2);
+                    g_vParam3_PS?.SetValue(actor.ShaderParameters.BodyOutlineParam3);
+                }
+                else
+                {
+                    g_vParam2_PS?.SetValue(new Vector4(0f, 0f, 1f, 0f));
+                    g_vParam3_PS?.SetValue(new Vector4(10f, 10000f, 0f, 0f));
+                }
+
                 return;
             }
 
@@ -1259,6 +1265,7 @@ namespace XenoKit.Engine.Shader
             if (MatParam.AlphaBlend == 1 && MatParam.AlphaBlendType != 3)
             {
                 depth.DepthBufferEnable = true;
+                depth.DepthBufferWriteEnable = false;
                 depth.DepthBufferFunction = CompareFunction.LessEqual;
                 depth.StencilEnable = false;
                 depth.StencilMask = 255;
@@ -1544,5 +1551,9 @@ namespace XenoKit.Engine.Shader
         public SimdVector4 g_vColor4_PS; //Tint color (RGB used, A ignored).
         public SimdVector4 g_vParam9_PS; //X = horizontal line size, Y = vertical line size, Z = gap between horizontal lines, W = gap between vertical lines
         public SimdVector4 g_vUserFlag1_VS; //X = Activate Path (115 = Vanish, 7936 = HC), Y = controls intensity of g_vColor4_PS (0 - 10 range, where 0 just tints the character, and 10 is fully opaque with no texture details) 
+        public bool BodyOutlineActive;
+        public SimdVector4 BodyOutlineColor;
+        public SimdVector4 BodyOutlineParam2;
+        public SimdVector4 BodyOutlineParam3;
     }
 }

--- a/XenoKit/Engine/Vertex/VertexPositionTexture5.cs
+++ b/XenoKit/Engine/Vertex/VertexPositionTexture5.cs
@@ -9,6 +9,7 @@ namespace XenoKit.Engine.Vertex
     {
         public Vector3 Position;
         public Vector2 TextureCoordinate;
+        public Color Color;
         public Vector2 TextureCoordinate2;
         public Vector2 TextureCoordinate3;
         public Vector2 TextureCoordinate4;
@@ -20,6 +21,7 @@ namespace XenoKit.Engine.Vertex
         {
             this.Position = position;
             this.TextureCoordinate = textureUv1;
+            this.Color = Microsoft.Xna.Framework.Color.White;
             TextureCoordinate2 = Vector2.Zero;
             TextureCoordinate3 = Vector2.Zero;
             TextureCoordinate4 = Vector2.Zero;
@@ -30,6 +32,7 @@ namespace XenoKit.Engine.Vertex
         {
             this.Position = position;
             this.TextureCoordinate = textureUv1;
+            this.Color = Microsoft.Xna.Framework.Color.White;
             this.TextureCoordinate2 = textureUv2;
             TextureCoordinate3 = Vector2.Zero;
             TextureCoordinate4 = Vector2.Zero;
@@ -40,6 +43,7 @@ namespace XenoKit.Engine.Vertex
         {
             this.Position = position;
             this.TextureCoordinate = textureUv1;
+            this.Color = Microsoft.Xna.Framework.Color.White;
             this.TextureCoordinate2 = textureUv2;
             TextureCoordinate3 = textureUv3;
             TextureCoordinate4 = textureUv4;
@@ -58,7 +62,7 @@ namespace XenoKit.Engine.Vertex
         {
             unchecked
             {
-                return (Position.GetHashCode() * 397) ^ TextureCoordinate.GetHashCode() ^ TextureCoordinate2.GetHashCode()
+                return (Position.GetHashCode() * 397) ^ Color.GetHashCode() ^ TextureCoordinate.GetHashCode() ^ TextureCoordinate2.GetHashCode()
                     ^ TextureCoordinate3.GetHashCode() ^ TextureCoordinate4.GetHashCode() ^ TextureCoordinate5.GetHashCode();
             }
         }
@@ -70,7 +74,7 @@ namespace XenoKit.Engine.Vertex
 
         public static bool operator ==(VertexPositionTexture5 left, VertexPositionTexture5 right)
         {
-            return ((left.Position == right.Position) && (left.TextureCoordinate == right.TextureCoordinate)
+            return ((left.Position == right.Position) && (left.Color == right.Color) && (left.TextureCoordinate == right.TextureCoordinate)
                 && (left.TextureCoordinate2 == right.TextureCoordinate2)
                 && (left.TextureCoordinate3 == right.TextureCoordinate3)
                 && (left.TextureCoordinate4 == right.TextureCoordinate4)
@@ -98,12 +102,13 @@ namespace XenoKit.Engine.Vertex
         static VertexPositionTexture5()
         {
             VertexElement[] elements = new VertexElement[] {
-                new VertexElement(0, VertexElementFormat.Vector2, VertexElementUsage.Position, 0),
+                new VertexElement(0, VertexElementFormat.Vector3, VertexElementUsage.Position, 0),
                 new VertexElement(12, VertexElementFormat.Vector2, VertexElementUsage.TextureCoordinate, 0),
-                new VertexElement(20, VertexElementFormat.Vector2, VertexElementUsage.TextureCoordinate, 1),
-                new VertexElement(28, VertexElementFormat.Vector2, VertexElementUsage.TextureCoordinate, 2),
-                new VertexElement(36, VertexElementFormat.Vector2, VertexElementUsage.TextureCoordinate, 3),
-                new VertexElement(44, VertexElementFormat.Vector2, VertexElementUsage.TextureCoordinate, 4),
+                new VertexElement(20, VertexElementFormat.Color, VertexElementUsage.Color, 0),
+                new VertexElement(24, VertexElementFormat.Vector2, VertexElementUsage.TextureCoordinate, 1),
+                new VertexElement(32, VertexElementFormat.Vector2, VertexElementUsage.TextureCoordinate, 2),
+                new VertexElement(40, VertexElementFormat.Vector2, VertexElementUsage.TextureCoordinate, 3),
+                new VertexElement(48, VertexElementFormat.Vector2, VertexElementUsage.TextureCoordinate, 4),
             };
             VertexDeclaration declaration = new VertexDeclaration(elements);
             VertexDeclaration = declaration;

--- a/XenoKit/Engine/Vfx/Particle/ParticleBillboard.cs
+++ b/XenoKit/Engine/Vfx/Particle/ParticleBillboard.cs
@@ -23,14 +23,22 @@ namespace XenoKit.Engine.Vfx.Particle
                 if (velocityOriented)
                 {
                     Matrix4x4 baseWorld = particle.Transform * attachBone;
-                    world = Matrix4x4.CreateConstrainedBillboard(baseWorld.Translation, particle.Camera.CameraState.Position, baseWorld.GetUp(), -MathHelpers.Up, SimdVector3.Zero) * Matrix4x4.CreateScale(particle.ParticleSystem.Scale);
+                    Matrix4x4 billboard = Matrix4x4.CreateFromAxisAngle(MathHelpers.Up, MathHelper.Pi) *
+                        Matrix4x4.CreateConstrainedBillboard(baseWorld.Translation, particle.Camera.CameraState.Position, baseWorld.GetUp(), -MathHelpers.Up, SimdVector3.Zero);
+                    billboard.Translation = SimdVector3.Zero;
+
+                    world = billboard *
+                            Matrix4x4.CreateScale(particle.ParticleSystem.Scale);
                     world.Translation = worldTranslation.Translation;
                 }
                 else
                 {
-                    world = Matrix4x4.CreateFromAxisAngle(MathHelpers.Up, MathHelper.Pi) *
+                    Matrix4x4 billboard = Matrix4x4.CreateFromAxisAngle(MathHelpers.Up, MathHelper.Pi) *
                             Matrix4x4.CreateFromAxisAngle(MathHelpers.Forward, MathHelper.ToRadians(-angle)) *
-                            MathHelpers.Invert(particle.Camera.ViewMatrix) *
+                            MathHelpers.Invert(particle.Camera.ViewMatrix);
+                    billboard.Translation = SimdVector3.Zero;
+
+                    world = billboard *
                             Matrix4x4.CreateScale(particle.ParticleSystem.Scale);
                     world.Translation = worldTranslation.Translation;
                 }
@@ -40,9 +48,11 @@ namespace XenoKit.Engine.Vfx.Particle
                 Matrix4x4 attachBone = particle.GetParticleAttachmentBone();
                 float angle = randomDirection ? -rotationAmount : rotationAmount;
                 Matrix4x4 baseWorld = particle.Transform * Matrix4x4.CreateScale(particle.ParticleSystem.Scale) * attachBone;
+                Matrix4x4 billboard = Matrix4x4.CreateFromAxisAngle(MathHelpers.Forward, MathHelper.ToRadians(-angle)) *
+                        Matrix4x4.CreateBillboard(baseWorld.Translation, attachBone.Translation, MathHelpers.Up, SimdVector3.Zero);
+                billboard.Translation = SimdVector3.Zero;
 
-                world = Matrix4x4.CreateFromAxisAngle(MathHelpers.Forward, MathHelper.ToRadians(-angle)) *
-                        Matrix4x4.CreateBillboard(baseWorld.Translation, attachBone.Translation, MathHelpers.Up, SimdVector3.Zero) *
+                world = billboard *
                         Matrix4x4.CreateScale(particle.ParticleSystem.Scale);
                 world.Translation = baseWorld.Translation;
             }

--- a/XenoKit/Engine/Vfx/Particle/ParticleEmitter.cs
+++ b/XenoKit/Engine/Vfx/Particle/ParticleEmitter.cs
@@ -113,12 +113,13 @@ namespace XenoKit.Engine.Vfx.Particle
 
                 // Generate a random angle within the specified range
                 float randomAngle = isEdgeIncrement ? EdgeIncrement * 360f : Xv2CoreLib.Random.Range(0, 360);
+                float randomAngleRadians = MathHelper.ToRadians(randomAngle);
 
                 // Calculate the position based on the random angle and radius
                 position = new SimdVector3(
-                        randomPosition * (float)Math.Cos(randomAngle),
+                        randomPosition * (float)Math.Cos(randomAngleRadians),
                         0f,
-                        randomPosition * (float)Math.Sin(randomAngle)
+                        randomPosition * (float)Math.Sin(randomAngleRadians)
                     );
             }
 
@@ -266,12 +267,13 @@ namespace XenoKit.Engine.Vfx.Particle
 
             float randomPosition = Xv2CoreLib.Random.Range(0, radius);
             float randomAngle = Xv2CoreLib.Random.Range(0, 360);
+            float randomAngleRadians = MathHelper.ToRadians(randomAngle);
 
             //Calculate the position based on the random angle and radius
             SimdVector3 position = new SimdVector3(
-                    randomPosition * (float)Math.Cos(randomAngle),
+                    randomPosition * (float)Math.Cos(randomAngleRadians),
                     0f,
-                    randomPosition * (float)Math.Sin(randomAngle)
+                    randomPosition * (float)Math.Sin(randomAngleRadians)
                 );
 
             SimdVector3 positionOffsetVector = new SimdVector3(0, positionOffset, 0);
@@ -311,12 +313,13 @@ namespace XenoKit.Engine.Vfx.Particle
 
             // Generate a random angle within the specified range
             float randomAngle = Xv2CoreLib.Random.Range(0, 360);
+            float randomAngleRadians = MathHelper.ToRadians(randomAngle);
 
             // Calculate the position based on the random angle and radius
             SimdVector3 position = new SimdVector3(
-                    randomPosition * (float)Math.Cos(randomAngle),
+                    randomPosition * (float)Math.Cos(randomAngleRadians),
                     0f,
-                    randomPosition * (float)Math.Sin(randomAngle)
+                    randomPosition * (float)Math.Sin(randomAngleRadians)
                 );
 
             SimdVector3 positionOffsetVector = new SimdVector3(0, positionOffset, 0);

--- a/XenoKit/Engine/Vfx/Particle/ParticlePlane.cs
+++ b/XenoKit/Engine/Vfx/Particle/ParticlePlane.cs
@@ -84,13 +84,24 @@ namespace XenoKit.Engine.Vfx.Particle
                         //This is not entirely correct.
                         //Matrix.CreateBillboard does not create the same result as in game. This method makes the particle always look at the current camera position, while in game it only cares about camera direction
                         //newWorld = Matrix.CreateFromAxisAngle(Vector3.Up, MathHelper.Pi) * Matrix.CreateConstrainedBillboard(world.Translation, CameraBase.CameraState.Position, world.Up, -Vector3.Up, null) * Matrix.CreateScale(ParticleSystem.Scale);
-                        newWorld = Matrix4x4.CreateConstrainedBillboard(world.Translation, Camera.CameraState.Position, world.GetUp(), -MathHelpers.Up, SimdVector3.Zero) * Matrix4x4.CreateScale(ParticleSystem.Scale);
+                        Matrix4x4 billboard = Matrix4x4.CreateFromAxisAngle(MathHelpers.Up, MathHelper.Pi) *
+                                   Matrix4x4.CreateConstrainedBillboard(world.Translation, Camera.CameraState.Position, world.GetUp(), -MathHelpers.Up, SimdVector3.Zero);
+                        billboard.Translation = SimdVector3.Zero;
+
+                        newWorld = billboard *
+                                   Matrix4x4.CreateScale(ParticleSystem.Scale);
                         
                         newWorld.Translation = worldTranslation.Translation;
                     }
                     else
                     {
-                        newWorld = Matrix4x4.CreateFromAxisAngle(MathHelpers.Up, MathHelper.Pi) * Matrix4x4.CreateFromAxisAngle(MathHelpers.Forward, MathHelper.ToRadians(-rotAmount)) * MathHelpers.Invert(Camera.ViewMatrix) * Matrix4x4.CreateScale(ParticleSystem.Scale);
+                        Matrix4x4 billboard = Matrix4x4.CreateFromAxisAngle(MathHelpers.Up, MathHelper.Pi) *
+                                   Matrix4x4.CreateFromAxisAngle(MathHelpers.Forward, MathHelper.ToRadians(-rotAmount)) *
+                                   MathHelpers.Invert(Camera.ViewMatrix);
+                        billboard.Translation = SimdVector3.Zero;
+
+                        newWorld = billboard *
+                                   Matrix4x4.CreateScale(ParticleSystem.Scale);
                         newWorld.Translation = worldTranslation.Translation;
                     }
                 }
@@ -99,8 +110,12 @@ namespace XenoKit.Engine.Vfx.Particle
                     Matrix4x4 attachBone = GetAttachmentBone();
                     float rotAmount = RandomDirection ? -RotationAmount : RotationAmount;
                     Matrix4x4 world = Transform * Matrix4x4.CreateScale(ParticleSystem.Scale) * attachBone;
+                    Matrix4x4 billboard = Matrix4x4.CreateFromAxisAngle(MathHelpers.Forward, MathHelper.ToRadians(-rotAmount)) *
+                               Matrix4x4.CreateBillboard(world.Translation, attachBone.Translation, MathHelpers.Up, SimdVector3.Zero);
+                    billboard.Translation = SimdVector3.Zero;
 
-                    newWorld = Matrix4x4.CreateFromAxisAngle(MathHelpers.Forward, MathHelper.ToRadians(-rotAmount)) * Matrix4x4.CreateBillboard(world.Translation, attachBone.Translation, MathHelpers.Up, SimdVector3.Zero) * Matrix4x4.CreateScale(ParticleSystem.Scale);
+                    newWorld = billboard *
+                               Matrix4x4.CreateScale(ParticleSystem.Scale);
                     newWorld.Translation = world.Translation;
                 }
                 else

--- a/XenoKit/Engine/Vfx/Particle/ParticleShapeDraw.cs
+++ b/XenoKit/Engine/Vfx/Particle/ParticleShapeDraw.cs
@@ -76,7 +76,7 @@ namespace XenoKit.Engine.Vfx.Particle
             if (Node.NodeFlags2.HasFlag(NodeFlags2.Unk2))
                 return ShapeDrawStripMode.PathNormalDepthBand;
 
-            return Node.NodeFlags2 == 0
+            return Node.NodeFlags2 == 0 || Node.NodeFlags2.HasFlag(NodeFlags2.Unk1)
                 ? ShapeDrawStripMode.PathNormalWidth
                 : ShapeDrawStripMode.UprightWidth;
         }

--- a/XenoKit/Views/GameView.xaml
+++ b/XenoKit/Views/GameView.xaml
@@ -14,7 +14,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="30"/>
             <RowDefinition Height="*"/>
-            <RowDefinition Height="90"/>
+            <RowDefinition Height="60"/>
         </Grid.RowDefinitions>
         <engine:Viewport Grid.Row="1" Margin="0,5,0,0" x:Name="monoGame" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"/>
         <StackPanel Grid.Row="1" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="10,15,0,0" Visibility="{Binding ElementName=UserControl, Path=OverlayVisibility}">
@@ -102,7 +102,6 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="40"/>
                 <RowDefinition Height="20"/>
-                <RowDefinition Height="25"/>
             </Grid.RowDefinitions>
             <StackPanel Grid.Row="0" HorizontalAlignment="Center" Orientation="Horizontal">
                 <Button Click="Play_Click"  Width="27" Style="{DynamicResource MahApps.Styles.Button.Circle}" Height="27">
@@ -121,19 +120,54 @@
 
             <Label Grid.Row="1" VerticalContentAlignment="Center" VerticalAlignment="Center" HorizontalAlignment="Right" Content="{Binding ElementName=UserControl, Path=CurrentFramePreview}" FontSize="14" Margin="0,0,0,0" Height="37" Width="75"/>
             <Slider Grid.Row="1" Margin="10,0,75,0" Maximum="{Binding ElementName=UserControl, Path=MaxFrameValue}" Value="{Binding ElementName=UserControl, Path=CurrentFrame}" Minimum="0" HorizontalAlignment="Stretch" VerticalAlignment="Bottom" ToolTip="Seek" Cursor="Hand"/>
-            <StackPanel Grid.Row="2" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="10,0,0,0.073" Orientation="Horizontal" Height="24" Width="Auto">
-                <CheckBox IsChecked="{Binding ElementName=UserControl, Path=RenderCharacters}" Content="Characters" Height="20" Margin="3, 0" ToolTip="Toggle the visibility of characters."/>
-                <CheckBox IsChecked="{Binding ElementName=UserControl, Path=Loop}" Content="Loop" Height="20" Margin="3, 0"/>
-                <CheckBox x:Name="bacLoopCheckBox" IsChecked="{Binding ElementName=UserControl, Path=BacLoop}" Content="BAC Loop" Height="20" Margin="3, 0" ToolTip="Toggle loops within Actions (BAC).&#x0a;&#x0a;These are the loops defined in a primary animation or function (0x0 / 0x22) entry."/>
-                <CheckBox IsChecked="{Binding ElementName=UserControl, Path=AutoPlay}" Content="Auto Play"  Height="20" ToolTip="Toggle autoplay. If enabled, then items will be auto-played when selected." Margin="3, 0"/>
-                <CheckBox x:Name="cameraCheckBox" IsChecked="{Binding ElementName=UserControl, Path=UseCameras}" Content="Cameras"  Height="20" ToolTip="Toggle camera animations." Margin="3, 0" Visibility="Collapsed"/>
-                <CheckBox x:Name="bonesCheckBox" IsChecked="{Binding ElementName=UserControl, Path=ShowVisualSkeleton}" Content="Bones" Height="20" ToolTip="Toggle the visual skeleton in the relevant tabs." Margin="3, 0" Visibility="Collapsed"/>
-                <CheckBox x:Name="audioCheckBox" IsChecked="{Binding ElementName=UserControl, Path=AudioSimulation}" Content="Sound" Height="20" ToolTip="Toggle audio simulation (does not affect audio previewing)." Margin="3, 0" Visibility="Collapsed"/>
-                <CheckBox x:Name="hitboxCheckBox" IsChecked="{Binding ElementName=UserControl, Path=HitboxSimulation}" Content="Hitbox" Height="20" ToolTip="Toggle hitbox simulation (does not affect hitbox previewing when editing a hitbox directly)." Margin="3, 0" Visibility="Collapsed"/>
-                <CheckBox x:Name="projectileCheckBox" IsChecked="{Binding ElementName=UserControl, Path=ProjectileSimulation}" Content="Projectiles" Height="20" ToolTip="Toggle projectile simulation." Margin="3, 0" Visibility="Collapsed"/>
-                <CheckBox x:Name="effectCheckBox" IsChecked="{Binding ElementName=UserControl, Path=VfxSimulation}" Content="Effect" Height="20" ToolTip="Toggle effect previewing." Margin="3, 0" Visibility="Collapsed"/>
+            <Grid Grid.Row="0" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,10,0" Height="22">
+                <ToggleButton x:Name="previewOptionsButton" Height="22" Padding="8,0" VerticalContentAlignment="Center" ToolTip="Show preview options.">
+                    <ToggleButton.Style>
+                        <Style TargetType="{x:Type ToggleButton}" BasedOn="{StaticResource MahApps.Styles.ToggleButton.Flat}">
+                            <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Transparent}"/>
+                            <Setter Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.Control.Border}"/>
+                            <Setter Property="BorderThickness" Value="1"/>
+                            <Setter Property="Foreground" Value="{DynamicResource MahApps.Brushes.Text}"/>
+                            <Style.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Gray.MouseOver}"/>
+                                    <Setter Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.Accent}"/>
+                                </Trigger>
+                                <Trigger Property="IsPressed" Value="True">
+                                    <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Gray.SemiTransparent}"/>
+                                </Trigger>
+                                <Trigger Property="IsChecked" Value="True">
+                                    <Setter Property="Background" Value="{DynamicResource MahApps.Brushes.Gray.SemiTransparent}"/>
+                                    <Setter Property="BorderBrush" Value="{DynamicResource MahApps.Brushes.Accent}"/>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </ToggleButton.Style>
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                        <iconPacks:PackIconMaterialLight Kind="FormatListChecks" Width="14" Height="14" VerticalAlignment="Center"/>
+                        <TextBlock Text="Preview" Margin="5,0,0,0" VerticalAlignment="Center"/>
+                        <iconPacks:PackIconMaterialLight Kind="ArrowUp" Width="10" Height="10" Margin="5,0,0,0" VerticalAlignment="Center"/>
+                    </StackPanel>
+                </ToggleButton>
+                <Popup x:Name="previewOptionsPopup" IsOpen="{Binding ElementName=previewOptionsButton, Path=IsChecked, Mode=TwoWay}" Placement="Top" PlacementTarget="{Binding ElementName=previewOptionsButton}" StaysOpen="False" AllowsTransparency="True" PopupAnimation="Fade">
+                    <Border MinWidth="170" Margin="0,0,0,4" Padding="8" Background="{DynamicResource MahApps.Brushes.ThemeBackground}" BorderBrush="{DynamicResource MahApps.Brushes.Control.Border}" BorderThickness="1" CornerRadius="2">
+                        <StackPanel>
+                            <CheckBox IsChecked="{Binding ElementName=UserControl, Path=RenderCharacters}" Content="Characters" Height="20" Margin="3, 0" ToolTip="Toggle the visibility of characters."/>
+                            <CheckBox IsChecked="{Binding ElementName=UserControl, Path=Loop}" Content="Loop" Height="20" Margin="3, 0"/>
+                            <CheckBox x:Name="bacLoopCheckBox" IsChecked="{Binding ElementName=UserControl, Path=BacLoop}" Content="BAC Loop" Height="20" Margin="3, 0" ToolTip="Toggle loops within Actions (BAC).&#x0a;&#x0a;These are the loops defined in a primary animation or function (0x0 / 0x22) entry."/>
+                            <CheckBox IsChecked="{Binding ElementName=UserControl, Path=AutoPlay}" Content="Auto Play"  Height="20" ToolTip="Toggle autoplay. If enabled, then items will be auto-played when selected." Margin="3, 0"/>
+                            <CheckBox x:Name="cameraCheckBox" IsChecked="{Binding ElementName=UserControl, Path=UseCameras}" Content="Cameras"  Height="20" ToolTip="Toggle camera animations." Margin="3, 0" Visibility="Collapsed"/>
+                            <CheckBox x:Name="bonesCheckBox" IsChecked="{Binding ElementName=UserControl, Path=ShowVisualSkeleton}" Content="Bones" Height="20" ToolTip="Toggle the visual skeleton in the relevant tabs." Margin="3, 0" Visibility="Collapsed"/>
+                            <CheckBox x:Name="audioCheckBox" IsChecked="{Binding ElementName=UserControl, Path=AudioSimulation}" Content="Sound" Height="20" ToolTip="Toggle audio simulation (does not affect audio previewing)." Margin="3, 0" Visibility="Collapsed"/>
+                            <CheckBox x:Name="hitboxCheckBox" IsChecked="{Binding ElementName=UserControl, Path=HitboxSimulation}" Content="Hitbox" Height="20" ToolTip="Toggle hitbox simulation (does not affect hitbox previewing when editing a hitbox directly)." Margin="3, 0" Visibility="Collapsed"/>
+                            <CheckBox x:Name="projectileCheckBox" IsChecked="{Binding ElementName=UserControl, Path=ProjectileSimulation}" Content="Projectiles" Height="20" ToolTip="Toggle projectile simulation." Margin="3, 0" Visibility="Collapsed"/>
+                            <CheckBox x:Name="bpeEffectCheckBox" IsChecked="{Binding ElementName=UserControl, Path=BpeSimulation}" Content="BPE" Height="20" ToolTip="Toggle BPE screen effects." Margin="3, 0" Visibility="Collapsed"/>
+                            <CheckBox x:Name="effectCheckBox" IsChecked="{Binding ElementName=UserControl, Path=VfxSimulation}" Content="Effect" Height="20" ToolTip="Toggle effect previewing." Margin="3, 0" Visibility="Collapsed"/>
 
-            </StackPanel>
+                        </StackPanel>
+                    </Border>
+                </Popup>
+            </Grid>
         </Grid>
     </Grid>
 </UserControl>

--- a/XenoKit/Views/GameView.xaml.cs
+++ b/XenoKit/Views/GameView.xaml.cs
@@ -359,6 +359,21 @@ namespace XenoKit.Controls
                 }
             }
         }
+        public bool BpeSimulation
+        {
+            get
+            {
+                return SettingsManager.settings.XenoKit_BpeSimulation;
+            }
+            set
+            {
+                if (SettingsManager.settings.XenoKit_BpeSimulation != value)
+                {
+                    SettingsManager.settings.XenoKit_BpeSimulation = value;
+                    SettingsManager.Instance.SaveSettings();
+                }
+            }
+        }
         public bool VfxSimulation
         {
             get
@@ -487,6 +502,7 @@ namespace XenoKit.Controls
             bonesCheckBox.Visibility = Visibility.Collapsed;
             hitboxCheckBox.Visibility = Visibility.Collapsed;
             projectileCheckBox.Visibility = Visibility.Collapsed;
+            bpeEffectCheckBox.Visibility = Visibility.Collapsed;
             effectCheckBox.Visibility = Visibility.Collapsed;
 
             if (SceneManager.IsOnTab(EditorTabs.Action, EditorTabs.Camera))
@@ -504,6 +520,7 @@ namespace XenoKit.Controls
                 bacLoopCheckBox.Visibility = Visibility.Visible;
                 audioCheckBox.Visibility = Visibility.Visible;
                 hitboxCheckBox.Visibility = Visibility.Visible;
+                bpeEffectCheckBox.Visibility = Visibility.Visible;
                 projectileCheckBox.Visibility = Visibility.Visible;
             }
 
@@ -522,6 +539,7 @@ namespace XenoKit.Controls
             NotifyPropertyChanged(nameof(AudioSimulation));
             NotifyPropertyChanged(nameof(HitboxSimulation));
             NotifyPropertyChanged(nameof(ProjectileSimulation));
+            NotifyPropertyChanged(nameof(BpeSimulation));
             NotifyPropertyChanged(nameof(VfxSimulation));
         }
 

--- a/XenoKit/XenoKit.csproj
+++ b/XenoKit/XenoKit.csproj
@@ -551,6 +551,7 @@
     <Compile Include="Engine\Objects\DrawableBoundingBox.cs" />
     <Compile Include="Engine\Scripting\BAC\ActionControl.cs" />
     <Compile Include="Engine\Scripting\BAC\BacEntryInstance.cs" />
+    <Compile Include="Engine\Scripting\BAC\BacScreenEffectEvaluator.cs" />
     <Compile Include="Engine\Scripting\BSA\BsaEffectPreviewController.cs" />
     <Compile Include="Engine\Scripting\BSA\BsaHitboxPreview.cs" />
     <Compile Include="Engine\Scripting\BSA\ProjectileInstance.cs" />


### PR DESCRIPTION
Adds preview support for BAC BPE screen effects, including blur, color filters, hue and inversion, zoom, and body outlines. BPE keyframes, loops, and disable entries are evaluated during playback. This also fixes related particle orientation and subtractive blending issues and adds a BPE option to the preview menu. Unknown BPE types 4 and 5 remain disabled.