### PR TITLE
Fix BAC animation duration with nonzero start frames

### DIFF
--- a/XenoKit/Engine/Scripting/BAC/BacEntryInstance.cs
+++ b/XenoKit/Engine/Scripting/BAC/BacEntryInstance.cs
@@ -215,7 +215,9 @@ namespace XenoKit.Engine.Scripting.BAC
 
                     if (anim != null && BAC_Type0.IsFullBodyAnimation(animationBacType.EanType))
                     {
-                        animTypeDuration = anim.FrameCount;
+                        animTypeDuration = animationBacType.StartTime == 0
+                            ? anim.FrameCount
+                            : anim.FrameCount - animationBacType.StartFrame;
                     }
                 }
             }

--- a/XenoKit/Views/GameView.xaml
+++ b/XenoKit/Views/GameView.xaml
@@ -104,20 +104,31 @@
                 <RowDefinition Height="20"/>
                 <RowDefinition Height="25"/>
             </Grid.RowDefinitions>
-            <StackPanel Grid.Row="0" HorizontalAlignment="Center" Orientation="Horizontal">
-                <Button Click="Play_Click"  Width="27" Style="{DynamicResource MahApps.Styles.Button.Circle}" Height="27">
-                    <iconPacks:PackIconMaterialLight Kind="{Binding PlayPauseButtonBinding}" />
-                </Button>
-                <Button  Click="Stop_Click" Margin="5,0,0,0"  Width="27" Style="{DynamicResource MahApps.Styles.Button.Circle}" Height="27">
-                    <iconPacks:PackIconMaterialLight Kind="Stop" />
-                </Button>
-                <RepeatButton Command="{Binding ElementName=UserControl, Path=SeekPrevCommand}" Margin="5,0,0,0" Width="27" Style="{DynamicResource MahApps.Styles.Button.Circle}" Height="27">
-                    <iconPacks:PackIconMaterialLight Kind="SeekPrevious" />
-                </RepeatButton>
-                <RepeatButton Command="{Binding ElementName=UserControl, Path=SeekNextCommand}" Margin="5,0,0,0" Width="27" Style="{DynamicResource MahApps.Styles.Button.Circle}" Height="27">
-                    <iconPacks:PackIconMaterialLight Kind="SeekNext" />
-                </RepeatButton>
-            </StackPanel>
+            <Grid Grid.Row="0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="1" HorizontalAlignment="Center" Orientation="Horizontal">
+                    <Button Click="Play_Click"  Width="27" Style="{DynamicResource MahApps.Styles.Button.Circle}" Height="27">
+                        <iconPacks:PackIconMaterialLight Kind="{Binding PlayPauseButtonBinding}" />
+                    </Button>
+                    <Button  Click="Stop_Click" Margin="5,0,0,0"  Width="27" Style="{DynamicResource MahApps.Styles.Button.Circle}" Height="27">
+                        <iconPacks:PackIconMaterialLight Kind="Stop" />
+                    </Button>
+                    <RepeatButton Command="{Binding ElementName=UserControl, Path=SeekPrevCommand}" Margin="5,0,0,0" Width="27" Style="{DynamicResource MahApps.Styles.Button.Circle}" Height="27">
+                        <iconPacks:PackIconMaterialLight Kind="SeekPrevious" />
+                    </RepeatButton>
+                    <RepeatButton Command="{Binding ElementName=UserControl, Path=SeekNextCommand}" Margin="5,0,0,0" Width="27" Style="{DynamicResource MahApps.Styles.Button.Circle}" Height="27">
+                        <iconPacks:PackIconMaterialLight Kind="SeekNext" />
+                    </RepeatButton>
+                </StackPanel>
+                <StackPanel Grid.Column="2" Margin="10,0,0,0" Orientation="Horizontal">
+                    <Label VerticalContentAlignment="Center" Content="{Binding ElementName=UserControl, Path=TimeScale}" FontSize="12"/>
+                    <Label VerticalContentAlignment="Center" Content="{Binding ElementName=UserControl, Path=StateExtraInfo}" FontSize="12" Margin="10,0,0,0" FontStyle="Normal"/>
+                </StackPanel>
+            </Grid>
 
             <Label Grid.Row="1" VerticalContentAlignment="Center" VerticalAlignment="Center" HorizontalAlignment="Right" Content="{Binding ElementName=UserControl, Path=CurrentFramePreview}" FontSize="14" Margin="0,0,0,0" Height="37" Width="75"/>
             <Slider Grid.Row="1" Margin="10,0,75,0" Maximum="{Binding ElementName=UserControl, Path=MaxFrameValue}" Value="{Binding ElementName=UserControl, Path=CurrentFrame}" Minimum="0" HorizontalAlignment="Stretch" VerticalAlignment="Bottom" ToolTip="Seek" Cursor="Hand"/>


### PR DESCRIPTION
Corrects BAC animation duration when End Frame is 65535 and the animation starts after frame 0. The playback controls now show the time-scaled duration without moving the buttons away from the center.