### PR TITLE
Fix BAC and BSA hitbox preview geometry

### DIFF
--- a/XenoKit/Engine/Character/Actor.cs
+++ b/XenoKit/Engine/Character/Actor.cs
@@ -351,7 +351,7 @@ namespace XenoKit.Engine
         {
             if (!HitboxEnabled || Controller.InvulnerabilityFrames > 0 || Controller.FreezeActionFrames > 0) return false;
 
-            if (Hitbox.Intersects(hitbox.BoundingBox))
+            if (hitbox.IsSupported && Hitbox.Intersects(hitbox.BoundingBox))
             {
                 Xv2CoreLib.BDM.BDM_File bdm = Files.Instance.GetBdmFile(hitbox.Hitbox.bdmFile, hitbox.BacEntry.SkillMove, hitbox.BacEntry.User, false);
 

--- a/XenoKit/Engine/Collision/BacHitbox.cs
+++ b/XenoKit/Engine/Collision/BacHitbox.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using System;
 using XenoKit.Editor;
 using XenoKit.Engine.Scripting.BAC;
 using Xv2CoreLib.BAC;
@@ -33,8 +34,6 @@ namespace XenoKit.Engine.Collision
                 return world;
             }
         }
-        private SimdVector3 PreviousTranslation;
-
         public int Team;
 
         public readonly BacEntryInstance BacEntry;
@@ -42,6 +41,7 @@ namespace XenoKit.Engine.Collision
         public readonly Actor SpawnActor;
         public readonly BAC_Type1 Hitbox;
         public BoundingBox BoundingBox;
+        public bool IsSupported { get; private set; }
         private int boneIdx = -1;
         private bool isBaseBone = false;
 
@@ -73,9 +73,9 @@ namespace XenoKit.Engine.Collision
 
         public void UpdateHitbox()
         {
-            Matrix4x4 world = WorldMatrix;
-
-            if (world.Translation == PreviousTranslation) return; //No need to update
+            IsSupported = false;
+            if (SpawnActor == null)
+                return;
 
             CBS_Entry cbsEntry = SpawnActor.CharacterData.CbsEntry.Find(x => x.BodyId == SpawnActor.Skeleton.GetActiveBoneScaleId());
             float cbsScaling = 1f;
@@ -97,30 +97,85 @@ namespace XenoKit.Engine.Collision
             }
 
 
-            Vector3 hitboxVectorMin;
-            Vector3 hitboxVectorMax;
-            if (Hitbox.BoundingBoxType == BAC_Type1.BoundingBoxTypeEnum.MinMax)
-            {
-                hitboxVectorMin = new Vector3(Hitbox.MinX, (Hitbox.MinY + 0.5f), Hitbox.MinZ) * cbsScaling;
-                hitboxVectorMax = new Vector3(Hitbox.MaxX, Hitbox.MaxY, Hitbox.MaxZ) * cbsScaling;
-                BoundingBox = new BoundingBox(
-                    hitboxVectorMin + HitboxPosition + world.Translation, 
-                    hitboxVectorMax + HitboxPosition + world.Translation
-                );
-            }
-            else
-            {
-                Vector3 halfSize = new Vector3(Hitbox.Size) * cbsScaling / 2f;
+            if (!IsFinite(cbsScaling))
+                return;
 
-                hitboxVectorMin = -halfSize;
-                hitboxVectorMax = halfSize;
-                BoundingBox = new BoundingBox(
-                    hitboxVectorMin + HitboxPosition + world.Translation,
-                    hitboxVectorMax + HitboxPosition + world.Translation
-                );
-            }
+            HitboxPosition = new SimdVector3(Hitbox.PositionX, Hitbox.PositionY, Hitbox.PositionZ);
+            Matrix4x4 world = WorldMatrix;
+            SimdVector3 center = SimdVector3.Transform(HitboxPosition, world);
 
-            PreviousTranslation = world.Translation;
+            if (!IsFinite(center))
+                return;
+
+            switch ((int)Hitbox.BoundingBoxType)
+            {
+                case 0:
+                case 3:
+                    SetBoundsFromCenter(center, new SimdVector3(GetRadius(cbsScaling)));
+                    break;
+                case 1:
+                case 4:
+                    SimdVector3 endpointA = SimdVector3.Transform(
+                        HitboxPosition + new SimdVector3(Hitbox.MinX, Hitbox.MinY, Hitbox.MinZ) * cbsScaling,
+                        world);
+                    SimdVector3 endpointB = SimdVector3.Transform(
+                        HitboxPosition + new SimdVector3(Hitbox.MaxX, Hitbox.MaxY, Hitbox.MaxZ) * cbsScaling,
+                        world);
+                    float radius = GetRadius(cbsScaling);
+
+                    if (!IsFinite(endpointA) || !IsFinite(endpointB) || !IsFinite(radius) || radius <= 0f)
+                        return;
+
+                    SetBoundsFromMinMax(
+                        SimdVector3.Min(endpointA, endpointB) - new SimdVector3(radius),
+                        SimdVector3.Max(endpointA, endpointB) + new SimdVector3(radius));
+                    break;
+                case 2:
+                    SimdVector3 halfExtents = new SimdVector3(
+                        Math.Abs(Hitbox.Size),
+                        Math.Abs(Hitbox.MinX),
+                        Math.Abs(Hitbox.MinY)) * Math.Abs(cbsScaling);
+
+                    SetBoundsFromCenter(center, halfExtents);
+                    break;
+                default:
+                    return;
+            }
+        }
+
+        private float GetRadius(float cbsScaling)
+        {
+            return Math.Abs(Hitbox.Size * cbsScaling);
+        }
+
+        private void SetBoundsFromCenter(SimdVector3 center, SimdVector3 halfExtents)
+        {
+            if (!IsFinite(halfExtents))
+                return;
+
+            BoundingBox = new BoundingBox(
+                Extensions.ToXna(center - halfExtents),
+                Extensions.ToXna(center + halfExtents));
+            IsSupported = true;
+        }
+
+        private void SetBoundsFromMinMax(SimdVector3 min, SimdVector3 max)
+        {
+            if (!IsFinite(min) || !IsFinite(max))
+                return;
+
+            BoundingBox = new BoundingBox(Extensions.ToXna(min), Extensions.ToXna(max));
+            IsSupported = true;
+        }
+
+        private static bool IsFinite(float value)
+        {
+            return !float.IsNaN(value) && !float.IsInfinity(value);
+        }
+
+        private static bool IsFinite(SimdVector3 value)
+        {
+            return IsFinite(value.X) && IsFinite(value.Y) && IsFinite(value.Z);
         }
 
         public bool IsContextValid()
@@ -135,7 +190,7 @@ namespace XenoKit.Engine.Collision
             relativeDir = SimdVector3.Normalize(relativeDir);
             return relativeDir;
         }
-    
+
         public Matrix4x4 GetAbsoluteHitboxMatrix()
         {
             return WorldMatrix * Matrix4x4.CreateTranslation(HitboxPosition);

--- a/XenoKit/Engine/Collision/HitboxVisual.cs
+++ b/XenoKit/Engine/Collision/HitboxVisual.cs
@@ -1,0 +1,157 @@
+using System;
+using Microsoft.Xna.Framework;
+using XenoKit.Engine.Shapes;
+
+namespace XenoKit.Engine.Collision
+{
+    public class HitboxVisual : EngineObject, IDisposable
+    {
+        private enum ShapeType
+        {
+            None,
+            Sphere,
+            Capsule,
+            Box
+        }
+
+        private readonly Color fillColor;
+        private readonly Color wireColor;
+        private readonly Cube boxFill;
+        private readonly Cube boxWireframe;
+        private Sphere sphere;
+        private Capsule capsule;
+        private Vector3 spherePosition;
+        private Vector3 boxPosition;
+        private float sphereRadius;
+        private Vector3 capsuleStart;
+        private Vector3 capsuleEnd;
+        private float capsuleRadius;
+        private ShapeType shapeType;
+
+        public HitboxVisual(Color fillColor, Color wireColor)
+        {
+            this.fillColor = fillColor;
+            this.wireColor = wireColor;
+            boxFill = new Cube(Vector3.Zero, new Vector3(-1f), new Vector3(1f), 0f, fillColor, false);
+            boxWireframe = new Cube(Vector3.Zero, new Vector3(-1f), new Vector3(1f), 0f, wireColor, true);
+        }
+
+        public void Clear()
+        {
+            shapeType = ShapeType.None;
+        }
+
+        public void SetSphere(Vector3 position, float radius)
+        {
+            if (!IsFinite(position) || !IsFinite(radius) || radius <= 0f)
+                return;
+
+            if (sphere == null || !AreClose(sphereRadius, radius))
+            {
+                sphere?.Dispose();
+                sphere = new Sphere(radius * 2f, true, 8);
+                sphereRadius = radius;
+            }
+
+            spherePosition = position;
+            shapeType = ShapeType.Sphere;
+        }
+
+        public void SetCapsule(Vector3 start, Vector3 end, float radius)
+        {
+            if (!IsFinite(start) || !IsFinite(end) || !IsFinite(radius) || radius <= 0f)
+                return;
+
+            if (Vector3.DistanceSquared(start, end) <= 0.0000001f)
+            {
+                SetSphere(start, radius);
+                return;
+            }
+
+            if (capsule == null ||
+                !AreClose(capsuleStart, start) ||
+                !AreClose(capsuleEnd, end) ||
+                !AreClose(capsuleRadius, radius))
+            {
+                capsule?.Dispose();
+                capsule = new Capsule(start, end, radius, true);
+                capsuleStart = start;
+                capsuleEnd = end;
+                capsuleRadius = radius;
+            }
+
+            shapeType = ShapeType.Capsule;
+        }
+
+        public void SetBox(Vector3 position, Vector3 halfExtents)
+        {
+            if (!IsFinite(position) || !IsFinite(halfExtents))
+                return;
+
+            halfExtents = new Vector3(
+                Math.Abs(halfExtents.X),
+                Math.Abs(halfExtents.Y),
+                Math.Abs(halfExtents.Z));
+
+            if (halfExtents.X <= 0f && halfExtents.Y <= 0f && halfExtents.Z <= 0f)
+                return;
+
+            boxFill.SetBounds(-halfExtents, halfExtents, 0f, true);
+            boxWireframe.SetBounds(-halfExtents, halfExtents, 0f, true);
+            boxPosition = position;
+            shapeType = ShapeType.Box;
+        }
+
+        public void Draw(Matrix world)
+        {
+            switch (shapeType)
+            {
+                case ShapeType.Sphere:
+                    Matrix sphereWorld = Matrix.CreateTranslation(spherePosition) * world;
+                    sphere.Draw(sphereWorld, Camera.ViewMatrix, Camera.ProjectionMatrix, fillColor);
+                    sphere.DrawWireframe(sphereWorld, Camera.ViewMatrix, Camera.ProjectionMatrix, wireColor);
+                    break;
+                case ShapeType.Capsule:
+                    Matrix capsuleWorld = capsule.LocalTransform * world;
+                    capsule.Draw(capsuleWorld, Camera.ViewMatrix, Camera.ProjectionMatrix, fillColor);
+                    capsule.DrawWireframe(capsuleWorld, Camera.ViewMatrix, Camera.ProjectionMatrix, wireColor);
+                    break;
+                case ShapeType.Box:
+                    boxFill.SetPosition(boxPosition);
+                    boxWireframe.SetPosition(boxPosition);
+                    boxFill.Draw(world);
+                    boxWireframe.Draw(world);
+                    break;
+            }
+        }
+
+        public void Dispose()
+        {
+            sphere?.Dispose();
+            sphere = null;
+            capsule?.Dispose();
+            capsule = null;
+            shapeType = ShapeType.None;
+        }
+
+        private static bool AreClose(float first, float second)
+        {
+            return Math.Abs(first - second) <= 0.000001f;
+        }
+
+        private static bool AreClose(Vector3 first, Vector3 second)
+        {
+            return Vector3.DistanceSquared(first, second) <= 0.0000001f;
+        }
+
+        private static bool IsFinite(float value)
+        {
+            return !float.IsNaN(value) && !float.IsInfinity(value);
+        }
+
+        private static bool IsFinite(Vector3 value)
+        {
+            return IsFinite(value.X) && IsFinite(value.Y) && IsFinite(value.Z);
+        }
+    }
+}

--- a/XenoKit/Engine/Gizmo/HitboxGizmo.cs
+++ b/XenoKit/Engine/Gizmo/HitboxGizmo.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
 using System;
 using XenoKit.Editor;
-using XenoKit.Engine.Shapes;
+using XenoKit.Engine.Scripting.BAC;
 using XenoKit.Engine.View;
 using Xv2CoreLib.BAC;
 using Xv2CoreLib.CBS;
@@ -32,7 +32,7 @@ namespace XenoKit.Engine.Gizmo
                 return world;
             }
         }
-        private Cube BoundingBox;
+        private readonly BacHitboxVisual HitboxVisual;
 
         private BAC_Type1 Hitbox = null;
         private Actor actor;
@@ -42,7 +42,7 @@ namespace XenoKit.Engine.Gizmo
 
         public HitboxGizmo() : base()
         {
-            BoundingBox = new Cube(new Vector3(0.5f), new Vector3(-0.5f), new Vector3(0.5f), 0.5f, Color.Green, true);
+            HitboxVisual = new BacHitboxVisual(new Color(255, 0, 0, 64), Color.Red);
             SceneManager.ActorChanged += SceneManager_ActorChanged;
         }
 
@@ -59,7 +59,7 @@ namespace XenoKit.Engine.Gizmo
         {
             if (IsContextValid() && actor != null)
             {
-                BoundingBox.Draw(WorldMatrix);
+                HitboxVisual.Draw(WorldMatrix);
             }
         }
 
@@ -89,7 +89,7 @@ namespace XenoKit.Engine.Gizmo
                 if(actor != null)
                 {
                     isBaseBone = boneName == Xv2CoreLib.ESK.ESK_File.BaseBone;
-                    boneIdx = SceneManager.Actors[0].Skeleton.GetBoneIndex(boneName);
+                    boneIdx = actor.Skeleton.GetBoneIndex(boneName);
                     CBS_Entry cbsEntry = actor.CharacterData.CbsEntry.Find(x => x.BodyId == actor.Skeleton.GetActiveBoneScaleId());
                     float cbsScaling = 1f;
 
@@ -109,14 +109,7 @@ namespace XenoKit.Engine.Gizmo
                         }
                     }
 
-                    //BAC Hitbox bounds are defined in half-metres (1.0 is actually 0.5)
-                    BoundingBox.SetBounds(
-                        new Vector3(hitbox.MinX, (Hitbox.MinY + 0.5f), hitbox.MinZ) * cbsScaling, 
-                        new Vector3(hitbox.MaxX, hitbox.MaxY, hitbox.MaxZ) * cbsScaling,
-                        hitbox.Size * cbsScaling / 2f, 
-                        hitbox.BoundingBoxType != BAC_Type1.BoundingBoxTypeEnum.Uniform
-                    );
-                    BoundingBox.SetPosition(new Vector3(hitbox.PositionX, hitbox.PositionY, hitbox.PositionZ));
+                    HitboxVisual.Update(hitbox, cbsScaling);
                 }
 
                 hitbox.PropertyChanged += Hitbox_PropertyChanged;

--- a/XenoKit/Engine/Scripting/BAC/BacHitboxVisual.cs
+++ b/XenoKit/Engine/Scripting/BAC/BacHitboxVisual.cs
@@ -1,0 +1,51 @@
+using System;
+using Microsoft.Xna.Framework;
+using XenoKit.Engine.Collision;
+using Xv2CoreLib.BAC;
+
+namespace XenoKit.Engine.Scripting.BAC
+{
+    public class BacHitboxVisual : HitboxVisual
+    {
+        public BacHitboxVisual(Color fillColor, Color wireColor)
+            : base(fillColor, wireColor)
+        {
+        }
+
+        public void Update(BAC_Type1 hitbox, float cbsScaling)
+        {
+            Clear();
+
+            if (hitbox == null)
+                return;
+
+            Vector3 position = new Vector3(hitbox.PositionX, hitbox.PositionY, hitbox.PositionZ);
+
+            switch ((int)hitbox.BoundingBoxType)
+            {
+                case 0:
+                    SetSphere(position, Math.Abs(hitbox.Size * cbsScaling));
+                    break;
+                case 1:
+                    Vector3 start = new Vector3(
+                        hitbox.PositionX + hitbox.MinX * cbsScaling,
+                        hitbox.PositionY + hitbox.MinY * cbsScaling,
+                        hitbox.PositionZ + hitbox.MinZ * cbsScaling);
+                    Vector3 end = new Vector3(
+                        hitbox.PositionX + hitbox.MaxX * cbsScaling,
+                        hitbox.PositionY + hitbox.MaxY * cbsScaling,
+                        hitbox.PositionZ + hitbox.MaxZ * cbsScaling);
+                    SetCapsule(start, end, Math.Abs(hitbox.Size * cbsScaling));
+                    break;
+                case 2:
+                    Vector3 halfExtents = new Vector3(
+                        hitbox.Size,
+                        hitbox.MinX,
+                        hitbox.MinY) * cbsScaling;
+                    SetBox(position, halfExtents);
+                    break;
+            }
+        }
+
+    }
+}

--- a/XenoKit/Engine/Scripting/BAC/Simulation/HitboxPreview.cs
+++ b/XenoKit/Engine/Scripting/BAC/Simulation/HitboxPreview.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using System;
-using System.Linq;
-using XenoKit.Engine.Shapes;
+using XenoKit.Engine.Scripting.BAC;
 using Xv2CoreLib.BAC;
 using Xv2CoreLib.CBS;
 using Xv2CoreLib.Resource.App;
@@ -33,7 +32,7 @@ namespace XenoKit.Engine.Scripting.BAC.Simulation
         }
 
         private readonly BAC_Type1 Hitbox;
-        private readonly Cube BoundingBox;
+        private readonly BacHitboxVisual HitboxVisual;
         private Actor actor;
         private int boneIdx = -1;
         private bool isBaseBone = false;
@@ -42,7 +41,7 @@ namespace XenoKit.Engine.Scripting.BAC.Simulation
         public HitboxPreview(BAC_Type1 hitbox, BacEntryInstance bacEntryInstance) : base(hitbox, bacEntryInstance)
         {
             Hitbox = hitbox;
-            BoundingBox = new Cube(new Vector3(0.5f), new Vector3(-0.5f), new Vector3(0.5f), 0.5f, Color.Blue, true);
+            HitboxVisual = new BacHitboxVisual(new Color(255, 0, 0, 64), Color.Red);
 
             UpdateHitbox();
             Hitbox.PropertyChanged += Hitbox_PropertyChanged;
@@ -61,7 +60,7 @@ namespace XenoKit.Engine.Scripting.BAC.Simulation
         {
             if (IsContextValid() && actor != null)
             {
-                BoundingBox.Draw(WorldMatrix);
+                HitboxVisual.Draw(WorldMatrix);
             }
         }
 
@@ -88,7 +87,7 @@ namespace XenoKit.Engine.Scripting.BAC.Simulation
                 if(actor != null)
                 {
                     isBaseBone = boneName == Xv2CoreLib.ESK.ESK_File.BaseBone;
-                    boneIdx = SceneManager.Actors[0].Skeleton.GetBoneIndex(boneName);
+                    boneIdx = actor.Skeleton.GetBoneIndex(boneName);
                     CBS_Entry cbsEntry = actor.CharacterData.CbsEntry.Find(x => x.BodyId == actor.Skeleton.GetActiveBoneScaleId());
                     float cbsScaling = 1f;
 
@@ -108,14 +107,7 @@ namespace XenoKit.Engine.Scripting.BAC.Simulation
                         }
                     }
 
-                    //BAC Hitbox bounds are defined in half-metres (1.0 is actually 0.5)
-                    BoundingBox.SetBounds(
-                        new Vector3(Hitbox.MinX, (Hitbox.MinY + 0.5f), Hitbox.MinZ) * cbsScaling, 
-                        new Vector3(Hitbox.MaxX, Hitbox.MaxY, Hitbox.MaxZ) * cbsScaling,
-                        Hitbox.Size * cbsScaling / 2f, 
-                        Hitbox.BoundingBoxType != BAC_Type1.BoundingBoxTypeEnum.Uniform
-                    );
-                    BoundingBox.SetPosition(new Vector3(Hitbox.PositionX, Hitbox.PositionY, Hitbox.PositionZ));
+                    HitboxVisual.Update(Hitbox, cbsScaling);
                 }
             }
         }
@@ -129,6 +121,8 @@ namespace XenoKit.Engine.Scripting.BAC.Simulation
         {
             if(Hitbox != null)
                 Hitbox.PropertyChanged -= Hitbox_PropertyChanged;
+
+            HitboxVisual.Dispose();
         }
 
         protected override bool IsContextValid()

--- a/XenoKit/Engine/Scripting/BSA/BsaHitboxGeometry.cs
+++ b/XenoKit/Engine/Scripting/BSA/BsaHitboxGeometry.cs
@@ -1,0 +1,12 @@
+using Xv2CoreLib.BSA;
+
+namespace XenoKit.Engine.Scripting.BSA
+{
+    internal static class BsaHitboxGeometry
+    {
+        public static bool UsesDistanceRelativeGeometry(BSA_Type3 hitbox)
+        {
+            return hitbox != null && hitbox.I_00 == 1 && (hitbox.I_04 & 0x0001) != 0;
+        }
+    }
+}

--- a/XenoKit/Engine/Scripting/BSA/BsaHitboxPreview.cs
+++ b/XenoKit/Engine/Scripting/BSA/BsaHitboxPreview.cs
@@ -1,7 +1,6 @@
 using System;
 using Microsoft.Xna.Framework;
-using XenoKit.Engine.Shapes;
-using Xv2CoreLib.BAC;
+using XenoKit.Engine.Collision;
 using Xv2CoreLib.BSA;
 using Xv2CoreLib.Resource.App;
 using Matrix4x4 = System.Numerics.Matrix4x4;
@@ -16,7 +15,7 @@ namespace XenoKit.Engine.Scripting.BSA
         private readonly Func<Matrix4x4> getDrawMatrix;
         private readonly Func<int> getFrame;
         private readonly Func<SimdVector3> getStartRelativeMovementDelta;
-        private readonly Cube boundingBox;
+        private readonly HitboxVisual hitboxVisual;
 
         public BsaHitboxPreview(BSA_Type3 hitbox, Func<Matrix4x4> getDrawMatrix, Func<int> getFrame, Func<SimdVector3> getStartRelativeMovementDelta)
         {
@@ -24,7 +23,7 @@ namespace XenoKit.Engine.Scripting.BSA
             this.getDrawMatrix = getDrawMatrix;
             this.getFrame = getFrame;
             this.getStartRelativeMovementDelta = getStartRelativeMovementDelta;
-            boundingBox = new Cube(new Vector3(0.5f), new Vector3(-0.5f), new Vector3(0.5f), 0.5f, Color.Blue, true);
+            hitboxVisual = new HitboxVisual(new Color(255, 255, 0, 64), Color.Yellow);
 
             UpdateHitbox();
         }
@@ -39,63 +38,54 @@ namespace XenoKit.Engine.Scripting.BSA
             if (!IsContextValid())
                 return;
 
-            boundingBox.Draw(Extensions.ToXna(getDrawMatrix()));
+            hitboxVisual.Draw(Extensions.ToXna(getDrawMatrix()));
         }
 
         public void Dispose()
         {
+            hitboxVisual.Dispose();
         }
 
         private void UpdateHitbox()
         {
+            hitboxVisual.Clear();
+
             if (hitbox == null)
                 return;
 
-            bool useDefinedBounds = GetBoundsType() != BAC_Type1.BoundingBoxTypeEnum.Uniform;
-            bool growBounds = UsesGrowBounds();
-            SimdVector3 startRelativeMovementDelta = growBounds
-                ? getStartRelativeMovementDelta?.Invoke() ?? SimdVector3.Zero
-                : SimdVector3.Zero;
+            Vector3 position = new Vector3(hitbox.F_08, hitbox.F_12, hitbox.F_16);
 
-            if (useDefinedBounds)
-                SetMinMaxBounds(startRelativeMovementDelta, growBounds);
-            else
-                boundingBox.SetBounds(Vector3.Zero, Vector3.Zero, hitbox.F_20 / 2f, false);
-
-            boundingBox.SetPosition(new Vector3(hitbox.F_08, hitbox.F_12, hitbox.F_16));
+            switch (hitbox.I_00)
+            {
+                case 0:
+                    hitboxVisual.SetSphere(position, Math.Abs(hitbox.F_20));
+                    break;
+                case 1:
+                    SetCapsule(position, Math.Abs(hitbox.F_20));
+                    break;
+                case 2:
+                    Vector3 halfExtents = new Vector3(
+                        hitbox.F_20,
+                        hitbox.F_24,
+                        hitbox.F_28);
+                    hitboxVisual.SetBox(position, halfExtents);
+                    break;
+            }
         }
 
-        private void SetMinMaxBounds(SimdVector3 startRelativeMovementDelta, bool growBounds)
+        private void SetCapsule(Vector3 position, float radius)
         {
-            Vector3 rawMin = new Vector3(hitbox.F_36, hitbox.F_40, hitbox.F_44);
-            Vector3 rawMax = new Vector3(hitbox.F_24, hitbox.F_28, hitbox.F_32);
-            Vector3 size = new Vector3(hitbox.F_20 / 2f);
+            if (BsaHitboxGeometry.UsesDistanceRelativeGeometry(hitbox))
+            {
+                SimdVector3 movementDelta = getStartRelativeMovementDelta?.Invoke() ?? SimdVector3.Zero;
+                Vector3 movement = Extensions.ToXna(movementDelta);
+                hitboxVisual.SetCapsule(position, position + movement, radius);
+                return;
+            }
 
-            Vector3 movementDelta = growBounds
-                ? ToXnaVector(startRelativeMovementDelta)
-                : Vector3.Zero;
-
-            Vector3 movedMin = rawMin + movementDelta;
-            Vector3 movedMax = rawMax + movementDelta;
-
-            Vector3 finalMin = Vector3.Min(Vector3.Min(rawMin, rawMax), Vector3.Min(movedMin, movedMax)) - size;
-            Vector3 finalMax = Vector3.Max(Vector3.Max(rawMin, rawMax), Vector3.Max(movedMin, movedMax)) + size;
-            boundingBox.SetBounds(finalMin, finalMax, 0f, true);
-        }
-
-        private static Vector3 ToXnaVector(SimdVector3 value)
-        {
-            return new Vector3(value.X, value.Y, value.Z);
-        }
-
-        private bool UsesGrowBounds()
-        {
-            return GetBoundsType() == BAC_Type1.BoundingBoxTypeEnum.MinMax && hitbox.I_04 != 0;
-        }
-
-        private BAC_Type1.BoundingBoxTypeEnum GetBoundsType()
-        {
-            return (BAC_Type1.BoundingBoxTypeEnum)(hitbox.I_00 & 0x000F);
+            Vector3 start = position + new Vector3(hitbox.F_24, hitbox.F_28, hitbox.F_32);
+            Vector3 end = position + new Vector3(hitbox.F_36, hitbox.F_40, hitbox.F_44);
+            hitboxVisual.SetCapsule(start, end, radius);
         }
 
         private bool IsContextValid()
@@ -112,5 +102,6 @@ namespace XenoKit.Engine.Scripting.BSA
 
             return hitbox.Duration == 0 || frame < (int)hitbox.StartTime + hitbox.Duration;
         }
+
     }
 }

--- a/XenoKit/Engine/Scripting/BSA/ProjectileInstance.cs
+++ b/XenoKit/Engine/Scripting/BSA/ProjectileInstance.cs
@@ -478,9 +478,7 @@ namespace XenoKit.Engine.Scripting.BSA
 
         private static bool UsesGrowBounds(BSA_Type3 hitbox)
         {
-            return hitbox != null &&
-                   (BAC_Type1.BoundingBoxTypeEnum)(hitbox.I_00 & 0x000F) == BAC_Type1.BoundingBoxTypeEnum.MinMax &&
-                   hitbox.I_04 != 0;
+            return BsaHitboxGeometry.UsesDistanceRelativeGeometry(hitbox);
         }
 
         private SimdVector3 GetLocalMovementDelta(float startFrame, float endFrame)

--- a/XenoKit/Engine/Shapes/Capsule.cs
+++ b/XenoKit/Engine/Shapes/Capsule.cs
@@ -1,0 +1,150 @@
+﻿using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+
+namespace XenoKit.Engine.Shapes
+{
+    public class Capsule : GeometricPrimitive
+    {
+        public Matrix LocalTransform { get; private set; }
+
+        public Capsule(Vector3 start, Vector3 end, float radius, bool alwaysVisible = false, int radialSegments = 12, int hemisphereSegments = 3)
+        {
+            if (radialSegments < 3)
+                throw new ArgumentOutOfRangeException("radialSegments");
+
+            if (hemisphereSegments < 1)
+                throw new ArgumentOutOfRangeException("hemisphereSegments");
+
+            base.alwaysVisible = alwaysVisible;
+
+            Vector3 direction = end - start;
+            float length = direction.Length();
+            float halfLength = length / 2f;
+            float step = MathHelper.PiOver2 / hemisphereSegments;
+            var rings = new List<int>(hemisphereSegments * 2);
+
+            AddVertex(new Vector3(0f, -halfLength - radius, 0f), Vector3.Down);
+
+            for (int i = 1; i <= hemisphereSegments; i++)
+            {
+                float latitude = -MathHelper.PiOver2 + i * step;
+                float normalY = (float)Math.Sin(latitude);
+                float normalRadius = (float)Math.Cos(latitude);
+                rings.Add(AddRing(-halfLength + normalY * radius, radius * normalRadius, normalRadius, normalY, radialSegments));
+            }
+
+            rings.Add(AddRing(halfLength, radius, 1f, 0f, radialSegments));
+
+            for (int i = 1; i < hemisphereSegments; i++)
+            {
+                float latitude = i * step;
+                float normalY = (float)Math.Sin(latitude);
+                float normalRadius = (float)Math.Cos(latitude);
+                rings.Add(AddRing(halfLength + normalY * radius, radius * normalRadius, normalRadius, normalY, radialSegments));
+            }
+
+            for (int i = 0; i < radialSegments; i++)
+            {
+                AddIndex(0);
+                AddIndex(rings[0] + (i + 1) % radialSegments);
+                AddIndex(rings[0] + i);
+            }
+
+            for (int i = 0; i < rings.Count - 1; i++)
+            {
+                ConnectRings(rings[i], rings[i + 1], radialSegments);
+            }
+
+            int topPole = CurrentVertex;
+            AddVertex(new Vector3(0f, halfLength + radius, 0f), Vector3.Up);
+
+            for (int i = 0; i < radialSegments; i++)
+            {
+                AddIndex(topPole);
+                AddIndex(rings[rings.Count - 1] + (radialSegments - 2 - i + radialSegments) % radialSegments);
+                AddIndex(rings[rings.Count - 1] + (radialSegments - 1 - i + radialSegments) % radialSegments);
+            }
+
+            foreach (int ring in rings)
+            {
+                for (int i = 0; i < radialSegments; i++)
+                    AddWireframeLine(ring + i, ring + (i + 1) % radialSegments);
+            }
+
+            for (int i = 0; i < radialSegments; i++)
+            {
+                AddWireframeLine(0, rings[0] + i);
+
+                for (int ring = 0; ring < rings.Count - 1; ring++)
+                    AddWireframeLine(rings[ring] + i, rings[ring + 1] + i);
+
+                AddWireframeLine(rings[rings.Count - 1] + i, topPole);
+            }
+
+            InitializePrimitive(GraphicsDevice);
+            LocalTransform = CreateLocalTransform(start, end, length);
+        }
+
+        private int AddRing(float y, float ringRadius, float normalRadius, float normalY, int radialSegments)
+        {
+            int ringStart = CurrentVertex;
+
+            for (int i = 0; i < radialSegments; i++)
+            {
+                float longitude = i * MathHelper.TwoPi / radialSegments;
+                float x = (float)Math.Cos(longitude);
+                float z = (float)Math.Sin(longitude);
+                AddVertex(
+                    new Vector3(x * ringRadius, y, z * ringRadius),
+                    new Vector3(x * normalRadius, normalY, z * normalRadius));
+            }
+
+            return ringStart;
+        }
+
+        private void ConnectRings(int lowerRing, int upperRing, int radialSegments)
+        {
+            for (int i = 0; i < radialSegments; i++)
+            {
+                int next = (i + 1) % radialSegments;
+
+                AddIndex(lowerRing + i);
+                AddIndex(lowerRing + next);
+                AddIndex(upperRing + i);
+
+                AddIndex(lowerRing + next);
+                AddIndex(upperRing + next);
+                AddIndex(upperRing + i);
+            }
+        }
+
+        private static Matrix CreateLocalTransform(Vector3 start, Vector3 end, float length)
+        {
+            Vector3 midpoint = (start + end) / 2f;
+            if (length <= 0.0001f)
+                return Matrix.CreateTranslation(midpoint);
+
+            Vector3 direction = (end - start) / length;
+            float dot = MathHelper.Clamp(Vector3.Dot(Vector3.Up, direction), -1f, 1f);
+            Quaternion rotation;
+
+            if (dot > 0.9999f)
+            {
+                rotation = Quaternion.Identity;
+            }
+            else if (dot < -0.9999f)
+            {
+                rotation = Quaternion.CreateFromAxisAngle(Vector3.Right, MathHelper.Pi);
+            }
+            else
+            {
+                Vector3 axis = Vector3.Cross(Vector3.Up, direction);
+                axis.Normalize();
+                rotation = Quaternion.CreateFromAxisAngle(axis, (float)Math.Acos(dot));
+            }
+
+            return Matrix.CreateFromQuaternion(rotation) * Matrix.CreateTranslation(midpoint);
+        }
+    }
+}

--- a/XenoKit/Engine/Shapes/Cube.cs
+++ b/XenoKit/Engine/Shapes/Cube.cs
@@ -12,6 +12,7 @@ namespace XenoKit.Engine.Shapes
         private IndexBuffer IndexBuffer;
         private VertexPositionColorTexture[] Vertices { get; set; }
         private short[] Indices;
+        private short[] WireframeIndices;
         private BasicEffect Material;
         private RasterizerState rasterState;
 
@@ -73,57 +74,72 @@ namespace XenoKit.Engine.Shapes
             Material.VertexColorEnabled = true;
 
             Vertices = new VertexPositionColorTexture[8];
-            Indices = new short[36]; //6 * 6
+            if (Wireframe)
+            {
+                WireframeIndices = new short[]
+                {
+                    0, 1, 1, 3, 3, 2, 2, 0,
+                    6, 7, 7, 5, 5, 4, 4, 6,
+                    0, 6, 1, 7, 2, 4, 3, 5
+                };
+            }
+            else
+            {
+                Indices = new short[36]; //6 * 6
+            }
             CreateVertices();
 
-            //Create vertex index
-            //TOP
-            Indices[0] = 0;
-            Indices[1] = 1;
-            Indices[2] = 2;
-            Indices[3] = 1;
-            Indices[4] = 2;
-            Indices[5] = 3;
+            if (!Wireframe)
+            {
+                //Create vertex index
+                //TOP
+                Indices[0] = 0;
+                Indices[1] = 1;
+                Indices[2] = 2;
+                Indices[3] = 1;
+                Indices[4] = 2;
+                Indices[5] = 3;
 
-            //BOTTOM
-            Indices[6] = 4;
-            Indices[7] = 5;
-            Indices[8] = 6;
-            Indices[9] = 5;
-            Indices[10] = 6;
-            Indices[11] = 7;
+                //BOTTOM
+                Indices[6] = 4;
+                Indices[7] = 5;
+                Indices[8] = 6;
+                Indices[9] = 5;
+                Indices[10] = 6;
+                Indices[11] = 7;
 
-            //LEFT
-            Indices[12] = 0;
-            Indices[13] = 2;
-            Indices[14] = 4;
-            Indices[15] = 0;
-            Indices[16] = 4;
-            Indices[17] = 6;
+                //LEFT
+                Indices[12] = 0;
+                Indices[13] = 2;
+                Indices[14] = 4;
+                Indices[15] = 0;
+                Indices[16] = 4;
+                Indices[17] = 6;
 
-            //RIGHT
-            Indices[18] = 1;
-            Indices[19] = 3;
-            Indices[20] = 5;
-            Indices[21] = 1;
-            Indices[22] = 5;
-            Indices[23] = 7;
+                //RIGHT
+                Indices[18] = 1;
+                Indices[19] = 3;
+                Indices[20] = 5;
+                Indices[21] = 1;
+                Indices[22] = 5;
+                Indices[23] = 7;
 
-            //FRONT
-            Indices[24] = 0;
-            Indices[25] = 1;
-            Indices[26] = 6;
-            Indices[27] = 1;
-            Indices[28] = 6;
-            Indices[29] = 7;
+                //FRONT
+                Indices[24] = 0;
+                Indices[25] = 1;
+                Indices[26] = 6;
+                Indices[27] = 1;
+                Indices[28] = 6;
+                Indices[29] = 7;
 
-            //BACK
-            Indices[30] = 2;
-            Indices[31] = 3;
-            Indices[32] = 4;
-            Indices[33] = 3;
-            Indices[34] = 4;
-            Indices[35] = 5;
+                //BACK
+                Indices[30] = 2;
+                Indices[31] = 3;
+                Indices[32] = 4;
+                Indices[33] = 3;
+                Indices[34] = 4;
+                Indices[35] = 5;
+            }
 
             //CreateBuffers();
 
@@ -133,7 +149,7 @@ namespace XenoKit.Engine.Shapes
                 {
                     rasterState = new RasterizerState()
                     {
-                        FillMode = FillMode.WireFrame,
+                        FillMode = FillMode.Solid,
                         CullMode = CullMode.None
                     };
                 }
@@ -282,13 +298,16 @@ namespace XenoKit.Engine.Shapes
         {
             foreach (var pass in Material.CurrentTechnique.Passes)
             {
-                GraphicsDevice.BlendState = BlendState.Opaque;
+                GraphicsDevice.BlendState = Color.A < 255 ? BlendState.AlphaBlend : BlendState.Opaque;
                 GraphicsDevice.DepthStencilState = AlwaysVisible ? DepthStencilState.None : DepthStencilState.Default;
                 GraphicsDevice.RasterizerState = rasterState;
 
                 pass.Apply();
 
-                GraphicsDevice.DrawUserIndexedPrimitives(PrimitiveType.TriangleList, Vertices, 0, Vertices.Length, Indices, 0, 12);
+                PrimitiveType primitiveType = Wireframe ? PrimitiveType.LineList : PrimitiveType.TriangleList;
+                short[] drawIndices = Wireframe ? WireframeIndices : Indices;
+                int primitiveCount = Wireframe ? WireframeIndices.Length / 2 : Indices.Length / 3;
+                GraphicsDevice.DrawUserIndexedPrimitives(primitiveType, Vertices, 0, Vertices.Length, drawIndices, 0, primitiveCount);
                 //GraphicsDevice.SetVertexBuffer(VertexBuffer);
                 //GraphicsDevice.Indices = IndexBuffer;
                 //GraphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 0, 0, IndexBuffer.IndexCount / 3);

--- a/XenoKit/Engine/Shapes/GeometricPrimitive.cs
+++ b/XenoKit/Engine/Shapes/GeometricPrimitive.cs
@@ -25,10 +25,14 @@ namespace XenoKit.Engine.Shapes
 
         List<VertexPositionNormal> vertices = new List<VertexPositionNormal>();
         List<ushort> indices = new List<ushort>();
+        List<ushort> wireframeIndices = new List<ushort>();
 
         VertexBuffer vertexBuffer;
         IndexBuffer indexBuffer;
+        IndexBuffer wireframeIndexBuffer;
+        int wireframePrimitiveCount;
         BasicEffect basicEffect;
+        RasterizerState wireframeRasterizerState;
 
 
         #endregion
@@ -49,6 +53,18 @@ namespace XenoKit.Engine.Shapes
                 throw new ArgumentOutOfRangeException("index");
 
             indices.Add((ushort)index);
+        }
+
+        protected void AddWireframeLine(int startIndex, int endIndex)
+        {
+            if (startIndex > ushort.MaxValue)
+                throw new ArgumentOutOfRangeException("startIndex");
+
+            if (endIndex > ushort.MaxValue)
+                throw new ArgumentOutOfRangeException("endIndex");
+
+            wireframeIndices.Add((ushort)startIndex);
+            wireframeIndices.Add((ushort)endIndex);
         }
 
         protected int CurrentVertex
@@ -72,6 +88,20 @@ namespace XenoKit.Engine.Shapes
                                           indices.Count, BufferUsage.None);
 
             indexBuffer.SetData(indices.ToArray());
+
+            if (wireframeIndices.Count > 0)
+            {
+                wireframeIndexBuffer = new IndexBuffer(graphicsDevice, typeof(ushort),
+                                                        wireframeIndices.Count, BufferUsage.None);
+                wireframeIndexBuffer.SetData(wireframeIndices.ToArray());
+                wireframePrimitiveCount = wireframeIndices.Count / 2;
+                wireframeIndices = null;
+                wireframeRasterizerState = new RasterizerState()
+                {
+                    FillMode = FillMode.Solid,
+                    CullMode = CullMode.None
+                };
+            }
 
             // Create a BasicEffect, which will be used to render the primitive.
             basicEffect = new BasicEffect(graphicsDevice);
@@ -113,8 +143,14 @@ namespace XenoKit.Engine.Shapes
                 if (indexBuffer != null)
                     indexBuffer.Dispose();
 
+                if (wireframeIndexBuffer != null)
+                    wireframeIndexBuffer.Dispose();
+
                 if (basicEffect != null)
                     basicEffect.Dispose();
+
+                if (wireframeRasterizerState != null)
+                    wireframeRasterizerState.Dispose();
             }
         }
 
@@ -132,21 +168,21 @@ namespace XenoKit.Engine.Shapes
         /// </summary>
         public void Draw(Effect effect)
         {
-            // Set our vertex declaration, vertex buffer, and index buffer.
+            Draw(effect, indexBuffer, PrimitiveType.TriangleList, indices.Count / 3);
+        }
+
+        private void Draw(Effect effect, IndexBuffer buffer, PrimitiveType primitiveType, int primitiveCount)
+        {
+            if (buffer == null || primitiveCount <= 0)
+                return;
+
             GraphicsDevice.SetVertexBuffer(vertexBuffer);
-
-            GraphicsDevice.Indices = indexBuffer;
-
+            GraphicsDevice.Indices = buffer;
 
             foreach (EffectPass effectPass in effect.CurrentTechnique.Passes)
             {
                 effectPass.Apply();
-
-                int primitiveCount = indices.Count / 3;
-
-                GraphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 0, 0, primitiveCount);
-                //GraphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 0, 0, vertices.Count, 0, primitiveCount);
-
+                GraphicsDevice.DrawIndexedPrimitives(primitiveType, 0, 0, primitiveCount);
             }
         }
 
@@ -183,6 +219,37 @@ namespace XenoKit.Engine.Shapes
 
             // Draw the model, using BasicEffect.
             Draw(basicEffect);
+        }
+
+        public void DrawWireframe(Matrix world, Matrix view, Matrix projection, Color color)
+        {
+            if (wireframeIndexBuffer == null || wireframePrimitiveCount <= 0)
+                return;
+
+            basicEffect.World = world;
+            basicEffect.View = view;
+            basicEffect.Projection = projection;
+            basicEffect.DiffuseColor = color.ToVector3();
+            basicEffect.Alpha = color.A / 255.0f;
+
+            GraphicsDevice device = basicEffect.GraphicsDevice;
+            device.DepthStencilState = (alwaysVisible) ? DepthStencilState.None : DepthStencilState.Default;
+            device.BlendState = color.A < 255 ? BlendState.AlphaBlend : BlendState.Opaque;
+
+            RasterizerState previousRasterizerState = device.RasterizerState;
+            bool previousLightingEnabled = basicEffect.LightingEnabled;
+            device.RasterizerState = wireframeRasterizerState;
+            basicEffect.LightingEnabled = false;
+
+            try
+            {
+                Draw(basicEffect, wireframeIndexBuffer, PrimitiveType.LineList, wireframePrimitiveCount);
+            }
+            finally
+            {
+                basicEffect.LightingEnabled = previousLightingEnabled;
+                device.RasterizerState = previousRasterizerState;
+            }
         }
 
 

--- a/XenoKit/Engine/Shapes/Sphere.cs
+++ b/XenoKit/Engine/Shapes/Sphere.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
+using System.Collections.Generic;
 
 namespace XenoKit.Engine.Shapes
 {
@@ -15,6 +16,7 @@ namespace XenoKit.Engine.Shapes
 
             int verticalSegments = tessellation;
             int horizontalSegments = tessellation * 2;
+            var ringStarts = new List<int>(verticalSegments - 1);
 
             float radius = diameter / 2;
 
@@ -30,6 +32,7 @@ namespace XenoKit.Engine.Shapes
                 float dxz = (float)Math.Cos(latitude);
 
                 // Create a single ring of vertices at this latitude.
+                ringStarts.Add(CurrentVertex);
                 for (int j = 0; j < horizontalSegments; j++)
                 {
                     float longitude = j * MathHelper.TwoPi / horizontalSegments;
@@ -44,40 +47,58 @@ namespace XenoKit.Engine.Shapes
             }
 
             // Finish with a single vertex at the top of the sphere.
+            int topPole = CurrentVertex;
             AddVertex(Vector3.Up * radius, Vector3.Up);
 
             // Create a fan connecting the bottom vertex to the bottom latitude ring.
             for (int i = 0; i < horizontalSegments; i++)
             {
                 AddIndex(0);
-                AddIndex(1 + (i + 1) % horizontalSegments);
-                AddIndex(1 + i);
+                AddIndex(ringStarts[0] + (i + 1) % horizontalSegments);
+                AddIndex(ringStarts[0] + i);
             }
 
             // Fill the sphere body with triangles joining each pair of latitude rings.
-            for (int i = 0; i < verticalSegments - 2; i++)
+            for (int i = 0; i < ringStarts.Count - 1; i++)
             {
                 for (int j = 0; j < horizontalSegments; j++)
                 {
-                    int nextI = i + 1;
                     int nextJ = (j + 1) % horizontalSegments;
+                    int lowerRing = ringStarts[i];
+                    int upperRing = ringStarts[i + 1];
 
-                    AddIndex(1 + i * horizontalSegments + j);
-                    AddIndex(1 + i * horizontalSegments + nextJ);
-                    AddIndex(1 + nextI * horizontalSegments + j);
+                    AddIndex(lowerRing + j);
+                    AddIndex(lowerRing + nextJ);
+                    AddIndex(upperRing + j);
 
-                    AddIndex(1 + i * horizontalSegments + nextJ);
-                    AddIndex(1 + nextI * horizontalSegments + nextJ);
-                    AddIndex(1 + nextI * horizontalSegments + j);
+                    AddIndex(lowerRing + nextJ);
+                    AddIndex(upperRing + nextJ);
+                    AddIndex(upperRing + j);
                 }
             }
 
             // Create a fan connecting the top vertex to the top latitude ring.
             for (int i = 0; i < horizontalSegments; i++)
             {
-                AddIndex(CurrentVertex - 1);
-                AddIndex(CurrentVertex - 2 - (i + 1) % horizontalSegments);
-                AddIndex(CurrentVertex - 2 - i);
+                AddIndex(topPole);
+                AddIndex(topPole - 1 - (i + 1) % horizontalSegments);
+                AddIndex(topPole - 1 - i);
+            }
+
+            foreach (int ringStart in ringStarts)
+            {
+                for (int i = 0; i < horizontalSegments; i++)
+                    AddWireframeLine(ringStart + i, ringStart + (i + 1) % horizontalSegments);
+            }
+
+            for (int i = 0; i < horizontalSegments; i++)
+            {
+                AddWireframeLine(0, ringStarts[0] + i);
+
+                for (int ring = 0; ring < ringStarts.Count - 1; ring++)
+                    AddWireframeLine(ringStarts[ring] + i, ringStarts[ring + 1] + i);
+
+                AddWireframeLine(ringStarts[ringStarts.Count - 1] + i, topPole);
             }
 
             InitializePrimitive(GraphicsDevice);

--- a/XenoKit/XenoKit.csproj
+++ b/XenoKit/XenoKit.csproj
@@ -468,6 +468,7 @@
     <Compile Include="Engine\Collision\AabbNode.cs" />
     <Compile Include="Engine\Collision\AabbTree.cs" />
     <Compile Include="Engine\Collision\BacHitbox.cs" />
+    <Compile Include="Engine\Collision\HitboxVisual.cs" />
     <Compile Include="Engine\Collision\TriangleBvhNode.cs" />
     <Compile Include="Engine\FrameRateCounter.cs" />
     <Compile Include="Engine\Gizmo\CurrentGizmo.cs" />
@@ -542,6 +543,7 @@
     <Compile Include="Engine\Scripting\BAC\Simulation\EyeMovementPositions.cs" />
     <Compile Include="Engine\Scripting\BAC\Simulation\HitboxPreview.cs" />
     <Compile Include="Engine\Scripting\BAC\Simulation\BacVisualCueObject.cs" />
+    <Compile Include="Engine\Scripting\BAC\BacHitboxVisual.cs" />
     <Compile Include="Engine\Shader\PostShaderEffect.cs" />
     <Compile Include="Engine\Shapes\GizmoGeometry.cs" />
     <Compile Include="Engine\Gizmo\TransformOperations\AnimationTransformOperation.cs" />
@@ -552,6 +554,7 @@
     <Compile Include="Engine\Scripting\BAC\ActionControl.cs" />
     <Compile Include="Engine\Scripting\BAC\BacEntryInstance.cs" />
     <Compile Include="Engine\Scripting\BSA\BsaEffectPreviewController.cs" />
+    <Compile Include="Engine\Scripting\BSA\BsaHitboxGeometry.cs" />
     <Compile Include="Engine\Scripting\BSA\BsaHitboxPreview.cs" />
     <Compile Include="Engine\Scripting\BSA\ProjectileInstance.cs" />
     <Compile Include="Engine\Scripting\ScriptEntity.cs" />
@@ -563,6 +566,7 @@
     <Compile Include="Engine\Shader\Xv2ShaderEffect.cs" />
     <Compile Include="Engine\Shader\Xv2Shader.cs" />
     <Compile Include="Engine\Shapes\GeometricPrimitive.cs" />
+    <Compile Include="Engine\Shapes\Capsule.cs" />
     <Compile Include="Engine\Shapes\Quad.cs" />
     <Compile Include="Engine\Objects\VisualBone.cs" />
     <Compile Include="Engine\Shapes\Sphere.cs" />


### PR DESCRIPTION
Corrects the position, rotation, scale, and shape of BAC and BSA hitbox previews. This adds capsule geometry, updates sphere and cube geometry, and keeps the hitbox gizmo aligned with the rendered preview.