### PR TITLE
Fix Vanish transparency effect rendering

### DIFF
--- a/XenoKit/Engine/CompiledObjectManager.cs
+++ b/XenoKit/Engine/CompiledObjectManager.cs
@@ -38,9 +38,13 @@ namespace XenoKit.Engine
         {
             if (key == null) return null;
 
+            object cacheKey = key;
+            if (typeof(T) == typeof(Xv2ShaderEffect))
+                cacheKey = Tuple.Create(key, shaderType);
+
             lock (CachedObjects)
             {
-                CachedObjects.TryGetValue(key, out CompiledObjectCacheEntry cacheEntry);
+                CachedObjects.TryGetValue(cacheKey, out CompiledObjectCacheEntry cacheEntry);
 
                 object result = cacheEntry?.CachedObject?.Target;
 
@@ -101,7 +105,7 @@ namespace XenoKit.Engine
                     {
                         try
                         {
-                            CachedObjects.Add(key, new CompiledObjectCacheEntry(key, result));
+                            CachedObjects.Add(cacheKey, new CompiledObjectCacheEntry(cacheKey, result));
                         }
                         catch
                         {
@@ -110,7 +114,7 @@ namespace XenoKit.Engine
                     }
                     else
                     {
-                        CachedObjects.Add(key, new CompiledObjectCacheEntry(key, result));
+                        CachedObjects.Add(cacheKey, new CompiledObjectCacheEntry(cacheKey, result));
                     }
                 }
 

--- a/XenoKit/Engine/Scripting/BAC/BacPlayer.cs
+++ b/XenoKit/Engine/Scripting/BAC/BacPlayer.cs
@@ -378,7 +378,7 @@ namespace XenoKit.Engine.Scripting.BAC
                                 MathHelper.Max((int)(transparency.HorizontalLineSize * fadeInFactor), transparency.HorizontalLineSize > 0 ? 1 : 0),
                                 MathHelper.Max((int)(transparency.VerticalLineSize * fadeInFactor), transparency.VerticalLineSize > 0 ? 1 : 0),
                                 MathHelper.Max((int)(transparency.HorizontalLineSpacing * fadeInFactor), transparency.HorizontalLineSpacing > 0 ? 1 : 0),
-                                MathHelper.Max((int)(transparency.VerticalLineSpacing * fadeInFactor), transparency.VerticalLineSpacing > 1 ? 0 : 0));
+                                MathHelper.Max((int)(transparency.VerticalLineSpacing * fadeInFactor), transparency.VerticalLineSpacing > 0 ? 1 : 0));
                             break;
                         case BAC_Type23.ShaderPathOptions.HC:
                             character.ShaderParameters.ShaderPath = Shader.ActorShaderPath.HC;

--- a/XenoKit/Engine/Scripting/BSA/BsaEffectPreviewController.cs
+++ b/XenoKit/Engine/Scripting/BSA/BsaEffectPreviewController.cs
@@ -67,7 +67,7 @@ namespace XenoKit.Engine.Scripting.BSA
             bsaFile = null;
             move = null;
             duration = 0;
-            Viewport.Instance?.VfxManager.StopEffects();
+            Viewport.Instance?.VfxManager?.StopEffects();
         }
 
         public void Update()
@@ -91,7 +91,7 @@ namespace XenoKit.Engine.Scripting.BSA
 
             if (projectile == null || projectile.IsFinished)
             {
-                Viewport.Instance?.VfxManager.StopEffects();
+                Viewport.Instance?.VfxManager?.StopEffects();
                 projectile?.Dispose();
                 projectile = ProjectileInstance.CreatePreview(SceneManager.Actors[0], move, entry, bsaFile, Matrix4x4.Identity);
             }
@@ -134,7 +134,7 @@ namespace XenoKit.Engine.Scripting.BSA
                 return;
             }
 
-            Viewport.Instance?.VfxManager.StopEffects();
+            Viewport.Instance?.VfxManager?.StopEffects();
             projectile?.Dispose();
             projectile = ProjectileInstance.CreatePreview(SceneManager.Actors[0], move, entry, bsaFile, Matrix4x4.Identity);
 
@@ -145,7 +145,7 @@ namespace XenoKit.Engine.Scripting.BSA
         private void AdvanceOneFrame()
         {
             projectile?.Update(1f);
-            Viewport.Instance?.VfxManager.Simulate();
+            Viewport.Instance?.VfxManager?.Simulate();
         }
 
         public void Draw()

--- a/XenoKit/Engine/Shader/Xv2ShaderEffect.cs
+++ b/XenoKit/Engine/Shader/Xv2ShaderEffect.cs
@@ -62,6 +62,7 @@ namespace XenoKit.Engine.Shader
         protected EffectParameter g_mVP_VS;
         protected EffectParameter g_mWVP_Prev_VS;
         protected EffectParameter g_mWV_VS;
+        protected EffectParameter g_mWV_VS_padding;
         protected EffectParameter g_mW_VS;
         protected EffectParameter g_mWIT_VS;
         protected EffectParameter g_mWLP_SM_VS;
@@ -86,7 +87,9 @@ namespace XenoKit.Engine.Shader
         protected EffectParameter g_vParam5_PS;
 
         protected EffectParameter g_vColor4_PS;
+        protected EffectParameter g_vParam8_PS;
         protected EffectParameter g_vParam9_PS;
+        protected EffectParameter g_vParam10_PS;
         protected EffectParameter g_vParam11_PS;
         protected EffectParameter g_vParam12_PS;
         protected EffectParameter g_vParam13_PS;
@@ -114,6 +117,7 @@ namespace XenoKit.Engine.Shader
         private static Vector4 HC_Param12 = new Vector4(-0.55689f, 0.79556f, -0.23867f, 1.00f);
         private static Vector4 HC_Param13 = new Vector4(8.00f, 0.40f, 0.00f, 0.00f);
         private static Vector4 HC_UserFlag1 = new Vector4(7936f, 0, 0.00f, 0.00f);
+        private const float VanishShaderFlag = 115f;
         private static readonly Vector4 DefaultBackgroundGlareTone = new Vector4(0.5f, 0.5f, 0.5f, 3.75f);
         private static readonly Vector4 DefaultEffectGlareTone = new Vector4(0.9f, 0.9f, 0.9f, 0.95f);
 
@@ -669,6 +673,7 @@ namespace XenoKit.Engine.Shader
             g_mVP_VS = Parameters["g_mVP_VS"];
             g_mWVP_Prev_VS = Parameters["g_mWVP_Prev_VS"];
             g_mWV_VS = Parameters["g_mWV_VS"];
+            g_mWV_VS_padding = Parameters["g_mWV_VS_padding"];
             g_mW_VS = Parameters["g_mW_VS"];
             g_mWIT_VS = Parameters["g_mWIT_VS"];
             g_mWLPB_SM_VS = Parameters["g_mWLPB_SM_VS"];
@@ -714,7 +719,9 @@ namespace XenoKit.Engine.Shader
             g_mMatrixPalette_VS = Parameters["g_mMatrixPalette_VS"];
 
             g_vColor4_PS = Parameters["g_vColor4_PS"];
+            g_vParam8_PS = Parameters["g_vParam8_PS"];
             g_vParam9_PS = Parameters["g_vParam9_PS"];
+            g_vParam10_PS = Parameters["g_vParam10_PS"];
             g_vParam11_PS = Parameters["g_vParam11_PS"];
             g_vParam12_PS = Parameters["g_vParam12_PS"];
             g_vParam13_PS = Parameters["g_vParam13_PS"];
@@ -916,17 +923,29 @@ namespace XenoKit.Engine.Shader
                     g_MaterialCol3_PS?.SetValue(new Vector4(SceneManager.BattleDamageScratches, SceneManager.BattleDamageBlood, Material.DecompiledParameters.MatCol3.B, Material.DecompiledParameters.MatCol3.A));
                 }
 
-                if (SceneManager.Actors[ActorSlot] != null)
+                Actor actor = SceneManager.Actors[ActorSlot];
+                if (actor != null)
                 {
-                    switch (SceneManager.Actors[ActorSlot].ShaderParameters.ShaderPath)
+                    ActorShaderPath shaderPath = actor.ShaderParameters.ShaderPath;
+                    if (shaderPath != ActorShaderPath.Vanish)
+                    {
+                        g_mWV_VS_padding?.SetValue(Vector4.Zero);
+                        g_vParam8_PS?.SetValue(Vector4.Zero);
+                        g_vParam10_PS?.SetValue(Vector4.Zero);
+                    }
+
+                    switch (shaderPath)
                     {
                         case ActorShaderPath.Default:
                             g_vUserFlag1_VS?.SetValue(Vector4.Zero);
                             break;
                         case ActorShaderPath.Vanish:
-                            g_vUserFlag1_VS?.SetValue(new Vector4(115f, SceneManager.Actors[ActorSlot].ShaderParameters.g_vUserFlag1_VS.Y, 0, 0));
-                            g_vColor4_PS?.SetValue(SceneManager.Actors[ActorSlot].ShaderParameters.g_vColor4_PS);
-                            g_vParam9_PS?.SetValue(SceneManager.Actors[ActorSlot].ShaderParameters.g_vParam9_PS);
+                            g_mWV_VS_padding?.SetValue(new Vector4(VanishShaderFlag, 0, 0, 0));
+                            g_vUserFlag1_VS?.SetValue(new Vector4(VanishShaderFlag, actor.ShaderParameters.g_vUserFlag1_VS.Y, 0, 0));
+                            g_vColor4_PS?.SetValue(actor.ShaderParameters.g_vColor4_PS);
+                            g_vParam8_PS?.SetValue(new Vector4(0f, 0f, 0.001f, 1f));
+                            g_vParam9_PS?.SetValue(actor.ShaderParameters.g_vParam9_PS);
+                            g_vParam10_PS?.SetValue(new Vector4(0f, 0f, 1f, 0f));
                             break;
                         case ActorShaderPath.HC:
                             g_vUserFlag1_VS?.SetValue(HC_UserFlag1);


### PR DESCRIPTION
Fixes Vanish transparency effects by setting the required shader values and separating incompatible shader variants in the compiled cache. It also prevents invalid VFX manager access during BSA effect cleanup and simulation.