### PR TITLE
Add a Stage BG effect preview toggle

### DIFF
--- a/XenoKit/Engine/Scripting/BAC/BacPlayer.cs
+++ b/XenoKit/Engine/Scripting/BAC/BacPlayer.cs
@@ -135,6 +135,7 @@ namespace XenoKit.Engine.Scripting.BAC
             IOrderedEnumerable<IBacType> validEntries = BacEntryInstance.BacEntry.IBacTypes.Where
                 (b => IsValidBacTypeTime(b) && (b.Flags == typeFlag || b.Flags == 0))
                 .OrderBy(x => x.GetType() == typeof(BAC_Type4)); //TimeScale must be resolved before animation/camera
+            var settings = SettingsManager.Instance.Settings;
 
             //Read bac types
             foreach (IBacType type in validEntries)
@@ -245,7 +246,9 @@ namespace XenoKit.Engine.Scripting.BAC
                 if (type is BAC_Type8 effect)
                 {
                     if ((effect.EffectFlags & BAC_Type8.EffectFlagsEnum.Loop) != BAC_Type8.EffectFlagsEnum.Loop && type.TimesActivated > 0) continue;
-                    if (!ActivationCheck(type) || !SettingsManager.Instance.Settings.XenoKit_VfxSimulation) continue;
+                    if (!ActivationCheck(type) ||
+                        !settings.XenoKit_VfxSimulation ||
+                        (effect.EepkType == BAC_Type8.EepkTypeEnum.StageBG && !settings.XenoKit_StageBgVfxSimulation)) continue;
 
                     if ((effect.EffectFlags & BAC_Type8.EffectFlagsEnum.Off) == BAC_Type8.EffectFlagsEnum.Off)
                     {
@@ -264,7 +267,7 @@ namespace XenoKit.Engine.Scripting.BAC
                                    (projectile.BsaFlags & BAC_Type9.BsaFlagsEnum.AllowLoop) == BAC_Type9.BsaFlagsEnum.AllowLoop;
 
                     if (!canLoop && type.TimesActivated > 0) continue;
-                    if (!ActivationCheck(type) || !SettingsManager.Instance.Settings.XenoKit_ProjectileSimulation) continue;
+                    if (!ActivationCheck(type) || !settings.XenoKit_ProjectileSimulation) continue;
 
                     BSA_File bsaFile = Files.Instance.GetBsaFile(projectile.BsaType, projectile.SkillID, BacEntryInstance.SkillMove, BacEntryInstance.User, true);
                     BSA_Entry bsaEntry = bsaFile?.BSA_Entries?.FirstOrDefault(entry => entry.SortID == projectile.EntryID);

--- a/XenoKit/Views/GameView.xaml
+++ b/XenoKit/Views/GameView.xaml
@@ -132,6 +132,7 @@
                 <CheckBox x:Name="hitboxCheckBox" IsChecked="{Binding ElementName=UserControl, Path=HitboxSimulation}" Content="Hitbox" Height="20" ToolTip="Toggle hitbox simulation (does not affect hitbox previewing when editing a hitbox directly)." Margin="3, 0" Visibility="Collapsed"/>
                 <CheckBox x:Name="projectileCheckBox" IsChecked="{Binding ElementName=UserControl, Path=ProjectileSimulation}" Content="Projectiles" Height="20" ToolTip="Toggle projectile simulation." Margin="3, 0" Visibility="Collapsed"/>
                 <CheckBox x:Name="effectCheckBox" IsChecked="{Binding ElementName=UserControl, Path=VfxSimulation}" Content="Effect" Height="20" ToolTip="Toggle effect previewing." Margin="3, 0" Visibility="Collapsed"/>
+                <CheckBox x:Name="stageBgEffectCheckBox" IsChecked="{Binding ElementName=UserControl, Path=StageBgVfxSimulation}" Content="Stage BG" Height="20" ToolTip="Toggle Stage BG effects." Margin="3, 0" Visibility="Collapsed"/>
 
             </StackPanel>
         </Grid>

--- a/XenoKit/Views/GameView.xaml.cs
+++ b/XenoKit/Views/GameView.xaml.cs
@@ -374,6 +374,21 @@ namespace XenoKit.Controls
                 }
             }
         }
+        public bool StageBgVfxSimulation
+        {
+            get
+            {
+                return SettingsManager.settings.XenoKit_StageBgVfxSimulation;
+            }
+            set
+            {
+                if (SettingsManager.settings.XenoKit_StageBgVfxSimulation != value)
+                {
+                    SettingsManager.settings.XenoKit_StageBgVfxSimulation = value;
+                    SettingsManager.Instance.SaveSettings();
+                }
+            }
+        }
         public bool RenderCharacters
         {
             get
@@ -488,6 +503,7 @@ namespace XenoKit.Controls
             hitboxCheckBox.Visibility = Visibility.Collapsed;
             projectileCheckBox.Visibility = Visibility.Collapsed;
             effectCheckBox.Visibility = Visibility.Collapsed;
+            stageBgEffectCheckBox.Visibility = Visibility.Collapsed;
 
             if (SceneManager.IsOnTab(EditorTabs.Action, EditorTabs.Camera))
             {
@@ -505,6 +521,7 @@ namespace XenoKit.Controls
                 audioCheckBox.Visibility = Visibility.Visible;
                 hitboxCheckBox.Visibility = Visibility.Visible;
                 projectileCheckBox.Visibility = Visibility.Visible;
+                stageBgEffectCheckBox.Visibility = Visibility.Visible;
             }
 
             if (SceneManager.IsOnTab(EditorTabs.Action, EditorTabs.Effect))
@@ -523,6 +540,7 @@ namespace XenoKit.Controls
             NotifyPropertyChanged(nameof(HitboxSimulation));
             NotifyPropertyChanged(nameof(ProjectileSimulation));
             NotifyPropertyChanged(nameof(VfxSimulation));
+            NotifyPropertyChanged(nameof(StageBgVfxSimulation));
         }
 
         private void UpdateCheckedButtons()


### PR DESCRIPTION
Adds a separate Stage BG preview option. Stage background effects can be disabled without disabling normal character and skill effects, and the setting is saved between sessions.