### PR TITLE
Match BAC camera playback and framing

### DIFF
--- a/XenoKit/Engine/Scripting/BAC/BacPlayer.cs
+++ b/XenoKit/Engine/Scripting/BAC/BacPlayer.cs
@@ -285,7 +285,7 @@ namespace XenoKit.Engine.Scripting.BAC
                 {
                     if (!ActivationCheck(type) || character.ActorSlot != 0) continue;
 
-                    EAN_File ean = Files.Instance.GetCamEanFile(camera.EanType, BacEntryInstance.SkillMove, BacEntryInstance.User, true, true);
+                    EAN_File ean = Files.Instance.GetCamEanFile(camera.EanType, BacEntryInstance.SkillMove, BacEntryInstance.User, true, camera.UseCharacterSpecificCameraEan);
 
                     if (ean != null && camera.EanIndex != ushort.MaxValue && SceneManager.UseCameras)
                     {

--- a/XenoKit/Engine/View/Camera.cs
+++ b/XenoKit/Engine/View/Camera.cs
@@ -7,12 +7,16 @@ using Xv2CoreLib.EAN;
 using Xv2CoreLib.Resource.App;
 using Xv2CoreLib.Resource.UndoRedo;
 using Matrix4x4 = System.Numerics.Matrix4x4;
+using SimdQuaternion = System.Numerics.Quaternion;
 using SimdVector3 = System.Numerics.Vector3;
 
 namespace XenoKit.Engine.View
 {
     public class Camera : CameraBase
     {
+        //When BAC transform modifiers are on, the game ignores the EAN roll/FoV curve and modifies this base FoV instead
+        private const float BacModifierBaseFieldOfView = 45f;
+
         //Camera State:
         private CameraState BackupCameraState = null;
 
@@ -137,9 +141,9 @@ namespace XenoKit.Engine.View
             float _drawFrame = (CurrentFrame <= cameraInstance.Animation.FrameCount) ? CurrentFrame : cameraInstance.Animation.FrameCount - 1;
 
             //If current frame is greater than animation duration, just leave the last frame playing
-            var pos = cameraInstance.Animation.GetNode("Node").GetComponent(EAN_AnimationComponent.ComponentType.Position);
-            var targetPos = cameraInstance.Animation.GetNode("Node").GetComponent(EAN_AnimationComponent.ComponentType.Rotation);
-            var camera = cameraInstance.Animation.GetNode("Node").GetComponent(EAN_AnimationComponent.ComponentType.Scale);
+            var cameraNode = cameraInstance.Animation.GetNode("Node");
+            var pos = cameraNode.GetComponent(EAN_AnimationComponent.ComponentType.Position);
+            var targetPos = cameraNode.GetComponent(EAN_AnimationComponent.ComponentType.Rotation);
 
             CameraState.Position.X = pos.GetKeyframeValue(_drawFrame, Axis.X);
             CameraState.Position.Y = pos.GetKeyframeValue(_drawFrame, Axis.Y);
@@ -148,24 +152,46 @@ namespace XenoKit.Engine.View
             CameraState.TargetPosition.Y = targetPos.GetKeyframeValue(_drawFrame, Axis.Y);
             CameraState.TargetPosition.Z = targetPos.GetKeyframeValue(_drawFrame, Axis.Z);
 
-            if (camera != null && !cameraInstance.bacCameraSettings.Enabled)
+            if (cameraInstance.bacCameraSettings.Enabled)
             {
-                CameraState.Roll = -MathHelper.ToDegrees(camera.GetKeyframeValue(_drawFrame, Axis.X));
-                CameraState.FieldOfView = MathHelper.ToDegrees(camera.GetKeyframeValue(_drawFrame, Axis.Y));
+                CameraState.Roll = 0f;
+                CameraState.FieldOfView = BacModifierBaseFieldOfView;
             }
             else
             {
-                CameraState.FieldOfView = EAN_File.DefaultFoV;
-                CameraState.Roll = 0f;
+                var camera = cameraNode.GetComponent(EAN_AnimationComponent.ComponentType.Scale);
+
+                if (camera != null)
+                {
+                    CameraState.Roll = MathHelper.ToDegrees(camera.GetKeyframeValue(_drawFrame, Axis.X));
+                    CameraState.FieldOfView = MathHelper.ToDegrees(camera.GetKeyframeValue(_drawFrame, Axis.Y));
+                }
+                else
+                {
+                    CameraState.FieldOfView = EAN_File.DefaultFoV;
+                    CameraState.Roll = 0f;
+                }
             }
 
             //Bone Focus
             if (SceneManager.CharacterExists(cameraInstance.cameraTarget.CharacterIndex) && !SceneManager.IsOnTab(EditorTabs.Camera))
             {
-                SimdVector3 bonePos = SceneManager.Actors[cameraInstance.cameraTarget.CharacterIndex].GetBoneCurrentAbsolutePosition(cameraInstance.cameraTarget.Bone);
+                Actor targetActor = SceneManager.Actors[cameraInstance.cameraTarget.CharacterIndex];
+                int boneIndex = targetActor.Skeleton.GetBoneIndex(cameraInstance.cameraTarget.Bone, true);
 
-                CameraState.Position += bonePos;
-                CameraState.TargetPosition += bonePos;
+                if (boneIndex != -1)
+                {
+                    //Camera animations use the actor's own space (CMN_CAM_FRONT and CMN_CAM_BACK sit on its -Z and +Z),
+                    //so the actor facing must rotate them. The bone only shifts the focus away from the actor root.
+                    //Root motion can carry scale on b_C_Base, and that scale resizes the shot, so only the facing and position apply here.
+                    if (Matrix4x4.Decompose(targetActor.Transform, out _, out SimdQuaternion actorFacing, out SimdVector3 actorPosition))
+                    {
+                        SimdVector3 boneOffset = targetActor.GetAbsoluteBoneMatrix(boneIndex).Translation - actorPosition;
+
+                        CameraState.Position = SimdVector3.Transform(CameraState.Position, actorFacing) + actorPosition + boneOffset;
+                        CameraState.TargetPosition = SimdVector3.Transform(CameraState.TargetPosition, actorFacing) + actorPosition + boneOffset;
+                    }
+                }
             }
 
             //Bac modifers
@@ -173,12 +199,7 @@ namespace XenoKit.Engine.View
             {
                 CameraState.Roll += cameraInstance.bacCameraSettings.GetCurrentRoll();
                 CameraState.FieldOfView += cameraInstance.bacCameraSettings.GetCurrentFoV();
-                CameraState.Position += cameraInstance.bacCameraSettings.GetCurrentRotation(CameraState.Position, CameraState.TargetPosition);
-
-                //I think Position Z offsets are not 100% correct... the target position seems off
-                SimdVector3 positionDelta = cameraInstance.bacCameraSettings.GetCurrentPosition(CameraState.Position, CameraState.TargetPosition);
-                CameraState.Position += positionDelta;
-                CameraState.TargetPosition += positionDelta;
+                cameraInstance.bacCameraSettings.ApplyTo(ref CameraState.Position, ref CameraState.TargetPosition);
             }
 
             //Scale animations to fit current actor size

--- a/XenoKit/Engine/View/CameraAnimationInstance.cs
+++ b/XenoKit/Engine/View/CameraAnimationInstance.cs
@@ -2,7 +2,6 @@
 using Xv2CoreLib.BAC;
 using Xv2CoreLib.EAN;
 using static Xv2CoreLib.ValuesDictionary.BAC;
-using Matrix4x4 = System.Numerics.Matrix4x4;
 using SimdVector3 = System.Numerics.Vector3;
 using SimdQuaternion = System.Numerics.Quaternion;
 using Xv2CoreLib.Resource;
@@ -100,6 +99,8 @@ namespace XenoKit.Engine.View
 
     public struct BacCameraSettings
     {
+        private const float BacModifierHorizontalOffsetScale = 1f / 6f;
+
         private readonly CameraAnimInstance ParentInstance;
         public bool Enabled;
         public ushort GlobalDuration;
@@ -120,8 +121,8 @@ namespace XenoKit.Engine.View
         public float RotY;
         public float RotZ; //Roll
         public float FoV;
-        public float DispXZ; //Not implementing
-        public float DispZY; //Not implementing
+        public float DispXZ;
+        public float DispZY;
 
         //Interpolated Values
         public float CurrentFoV
@@ -135,7 +136,7 @@ namespace XenoKit.Engine.View
         {
             get
             {
-                return (PosX) * GetFactor(PosXDuration);
+                return PosX * GetFactor(PosXDuration);
             }
         }
         public float CurrentPosY
@@ -152,6 +153,8 @@ namespace XenoKit.Engine.View
                 return PosZ * GetFactor(PosZDuration);
             }
         }
+        public float CurrentDispXZ => DispXZ * GetFactor(DispXZDuration);
+        public float CurrentDispZY => DispZY * GetFactor(DispZYDuration);
         public float CurrentRotX
         {
             get
@@ -173,8 +176,6 @@ namespace XenoKit.Engine.View
                 return RotZ * GetFactor(RotZDuration);
             }
         }
-
-        public bool IsRotationReversed;
 
         public BacCameraSettings(CameraAnimInstance camera)
         {
@@ -199,9 +200,6 @@ namespace XenoKit.Engine.View
             FovDuration = 0;
             DispXZDuration = 0;
             DispZYDuration = 0;
-
-            EAN_AnimationComponent pos = camera.Animation.GetNode("Node").GetComponent(EAN_AnimationComponent.ComponentType.Position);
-            IsRotationReversed = pos.GetKeyframeValue(0, Axis.Z) > 0f;
         }
 
         public BacCameraSettings(CameraAnimInstance camera, BAC_Type10 bacCameraEntry)
@@ -227,20 +225,46 @@ namespace XenoKit.Engine.View
             FovDuration = bacCameraEntry.FieldOfView_Duration;
             DispXZDuration = bacCameraEntry.DisplacementXZ_Duration;
             DispZYDuration = bacCameraEntry.DisplacementZY_Duration;
-
-            EAN_AnimationComponent pos = camera.Animation.GetNode("Node").GetComponent(EAN_AnimationComponent.ComponentType.Position);
-            IsRotationReversed = pos.GetKeyframeValue(0, Axis.Z) > 0f;
         }
 
-        public SimdVector3 GetCurrentPosition(SimdVector3 position, SimdVector3 targetPosition)
+        public void ApplyTo(ref SimdVector3 position, ref SimdVector3 targetPosition)
         {
-            SimdVector3 forward = targetPosition - position;
-            forward = SimdVector3.Normalize(forward);
+            SimdVector3 backward = position - targetPosition;
+            float originalDistance = backward.Length();
 
-            SimdVector3 posToMove = new SimdVector3(CurrentPosX, CurrentPosY, CurrentPosZ);
-            posToMove = SimdVector3.Transform(posToMove, Matrix4x4.CreateWorld(position, forward, MathHelpers.Up));
+            if (originalDistance <= float.Epsilon)
+                return;
 
-            return (posToMove - position) * CurrentGlobalFactor();
+            backward /= originalDistance;
+
+            float modifiedDistance = originalDistance + CurrentPosZ;
+            float currentDispXZ = CurrentDispXZ;
+            float currentDispZY = CurrentDispZY;
+
+            SimdVector3 modifiedBackward = RotateCameraDirection(backward, CurrentRotY, CurrentRotX);
+
+            SimdVector3 modifiedPosition = targetPosition + modifiedBackward * modifiedDistance;
+            SimdVector3 modifiedTargetPosition = targetPosition;
+
+            SimdVector3 positionOffset = GetCameraRight(modifiedBackward) * (CurrentPosX * BacModifierHorizontalOffsetScale);
+            modifiedPosition += positionOffset;
+            modifiedTargetPosition += positionOffset;
+
+            if (currentDispXZ != 0f || currentDispZY != 0f)
+            {
+                SimdVector3 aim = RotateCameraDirection(-modifiedBackward, currentDispXZ, currentDispZY);
+                modifiedTargetPosition = modifiedPosition + aim * modifiedDistance;
+            }
+
+            //PosY raises the whole shot, so it moves the target as well
+            SimdVector3 heightOffset = MathHelpers.Up * CurrentPosY;
+            modifiedPosition += heightOffset;
+            modifiedTargetPosition += heightOffset;
+
+            float factor = CurrentGlobalFactor();
+            position = SimdVector3.Lerp(position, modifiedPosition, factor);
+            targetPosition = SimdVector3.Lerp(targetPosition, modifiedTargetPosition, factor);
+
         }
 
         public float GetCurrentFoV()
@@ -251,32 +275,33 @@ namespace XenoKit.Engine.View
         public float GetCurrentRoll()
         {
             return CurrentRotZ * CurrentGlobalFactor();
-            //return IsRotationReversed ? -CurrentRotZ * CurrentGlobalFactor() : (CurrentRotZ) * CurrentGlobalFactor();
         }
 
-        public SimdVector3 GetCurrentRotation(SimdVector3 position, SimdVector3 targetPosition)
+        private SimdVector3 GetCameraRight(SimdVector3 backward)
         {
-            //Calculate the extra position needed to perform the rotation
-            //Calculate the WHOLE thing first, then multiply it by CurrentFactor
-            //This is how it is done in XV2. The result is multiplied, not the RotX,Y,Z values. (which results in the interpolation not actually rotating... just goes from point a to point b)
+            SimdVector3 right = SimdVector3.Cross(MathHelpers.Up, backward);
+            float rightLength = right.Length();
 
-            SimdVector3 newPosition;
+            return rightLength > float.Epsilon ? right / rightLength : right;
+        }
 
-            //Rotate Y
-            SimdVector3 temp = position - targetPosition;
-            temp = SimdVector3.Transform(temp, Matrix4x4.CreateRotationY(MathHelper.ToRadians(CurrentRotY)));
-            newPosition = targetPosition + temp;
+        //Yaw comes first, because the pitch axis is the right vector that the yaw produces
+        private SimdVector3 RotateCameraDirection(SimdVector3 direction, float yawDegrees, float pitchDegrees)
+        {
+            SimdVector3 yawed = direction;
 
-            //Rotate X
-            temp = newPosition - targetPosition;
+            if (yawDegrees != 0f)
+            {
+                SimdQuaternion yawRotation = SimdQuaternion.CreateFromAxisAngle(MathHelpers.Up, MathHelper.ToRadians(yawDegrees));
+                yawed = SimdVector3.Transform(yawed, yawRotation);
+            }
 
-            //CurrentRotX needs to be inverted based on the cameras Z position, else the rotation will happen in the wrong direction if the camera is behind the target
-            temp = IsRotationReversed ? SimdVector3.Transform(temp, Matrix4x4.CreateRotationX(MathHelper.ToRadians(CurrentRotX))) : SimdVector3.Transform(temp, Matrix4x4.CreateRotationX(MathHelper.ToRadians(-CurrentRotX)));
-            //temp = Vector3.Transform(temp, Matrix.CreateRotationX(MathHelper.ToRadians(CurrentRotX)));
+            if (pitchDegrees == 0f)
+                return yawed;
 
-            newPosition = targetPosition + temp;
+            SimdQuaternion pitchRotation = SimdQuaternion.CreateFromAxisAngle(GetCameraRight(yawed), MathHelper.ToRadians(pitchDegrees));
 
-            return (newPosition - position) * CurrentGlobalFactor();
+            return SimdVector3.Normalize(SimdVector3.Transform(yawed, pitchRotation));
         }
 
         private float CurrentGlobalFactor()

--- a/XenoKit/Engine/View/CameraBase.cs
+++ b/XenoKit/Engine/View/CameraBase.cs
@@ -358,7 +358,7 @@ namespace XenoKit.Engine.View
             float fieldOfViewRadians = (float)(Math.PI / 180 * CameraState.FieldOfView);
             float nearClipPlane = ViewportInstance.CurrentStage.NearClip;
             float farClipPlane = ViewportInstance.CurrentStage.FarClip;
-            float aspectRatio = GraphicsDevice.Viewport.Width / (float)GraphicsDevice.Viewport.Height;
+            float aspectRatio = RenderSystem.RenderWidth / (float)RenderSystem.RenderHeight;
 
             ProjectionMatrix = Matrix4x4.CreatePerspectiveFieldOfView(fieldOfViewRadians, aspectRatio, nearClipPlane, farClipPlane);
             //ProjectionMatrix = EngineUtils.CreateInfinitePerspective(fieldOfViewRadians, aspectRatio, nearClipPlane);
@@ -387,7 +387,7 @@ namespace XenoKit.Engine.View
         public void LookAt(BoundingBox box)
         {
             float fieldOfViewRadians = (float)(Math.PI / 180 * CameraState.FieldOfView);
-            float aspectRatio = GraphicsDevice.Viewport.Width / (float)GraphicsDevice.Viewport.Height;
+            float aspectRatio = RenderSystem.RenderWidth / (float)RenderSystem.RenderHeight;
 
             Vector3 boxCenter = (box.Min + box.Max) * 0.5f;
             Vector3 boxExtents = (box.Max - box.Min) * 0.5f;

--- a/XenoKit/Views/CameraTabView.xaml.cs
+++ b/XenoKit/Views/CameraTabView.xaml.cs
@@ -732,7 +732,7 @@ namespace XenoKit.Controls
             float rotX = Viewport.Instance.Camera.CameraState.TargetPosition.X;
             float rotY = Viewport.Instance.Camera.CameraState.TargetPosition.Y;
             float rotZ = Viewport.Instance.Camera.CameraState.TargetPosition.Z;
-            float scaleX = -MathHelper.ToRadians(Viewport.Instance.Camera.CameraState.Roll);
+            float scaleX = MathHelper.ToRadians(Viewport.Instance.Camera.CameraState.Roll);
             float scaleY = MathHelper.ToRadians(Viewport.Instance.Camera.CameraState.FieldOfView);
 
             //"Unscale" the camera if the current EAN file is not chara unique


### PR DESCRIPTION
Corrects BAC camera position, rotation, displacement, roll, and field-of-view modifiers. Camera animations now use actor space, respect character-specific camera EANs, and use the render target aspect ratio.